### PR TITLE
fix: cutscene mouth/speech timing and playback speed

### DIFF
--- a/include/wc1.h
+++ b/include/wc1.h
@@ -86,14 +86,19 @@ typedef unsigned int Wc2DwordPtr;
     LoadPacketIntoBuffer((fileName), (section), (record), 0)
 #endif
 
-/* One mouth position per cinematic frame is what the original animates, and
- * the cinematic rate is 20fps while a line is being spoken.  Nearly every
- * entry in the mouth-duration table is a single 60Hz tick, so the frame rate
- * is what actually paces the mouth: the clock gate only bites at 60 positions
- * a second.  The port has to name that cadence instead of inheriting it from
- * however fast the host happens to draw, or the mouth runs the line out well
- * before the speech does.  Three ticks is one frame at 20fps. */
-#define WC2_CUTSCENE_MOUTH_MIN_TICKS 3
+/* One mouth position per cinematic frame is what the original animates.
+ * Nearly every entry in the mouth-duration table is a single 60Hz tick, so
+ * without a floor the clock gate only bites at 60 positions a second --
+ * the port has to name a cadence instead of inheriting one from however
+ * fast the host happens to draw, or the mouth runs the line out well
+ * before the speech does. Was 3 ticks (one frame at 20fps, the rate
+ * PlayRawSpeechBuffer sets while speech is playing) -- correct for
+ * voiced lines, where actual audio length is the real pacing reference
+ * regardless of this floor's exact value, but unvoiced lines have
+ * nothing else limiting their pace, and 3 measured twice too fast there.
+ * 6 ticks (10 positions/sec) is the current best empirical value for the
+ * unvoiced case; not derived from a DOS trace. */
+#define WC2_CUTSCENE_MOUTH_MIN_TICKS 6
 
 /* Marks a routine that deliberately indexes out of one global and into the one
  * that follows it.  The original's data layout is what makes those reads land

--- a/src/screens.c
+++ b/src/screens.c
@@ -14,6 +14,16 @@
 static char g_szLastCutsceneWorkBuffer_00499ec0[16] = "@@@@@@@@@@";
 static char g_szLastCutscenePrintBuffer_00499ed0[16] = "@@@@@@@@@@";
 
+/* Not an original engine flag -- tracks whether any speech clip has
+ * actually played yet in the cutscene currently running (reset once per
+ * RunLoadedCutscene call, set the first time AnimateCutsceneSpeakerMouth
+ * observes g_bSpeechSoundActive_004a2660 go active). Most cutscenes have
+ * no voice audio at all, so AnimateCutsceneSpeakerMouth needs a way to
+ * tell "this line's audio hasn't started yet" (wait) apart from "this
+ * cutscene has no audio" (animate from text, same as the original always
+ * did) -- otherwise every unvoiced line blocks forever. */
+static signed char g_bCutsceneSpeechAudioSeen = 0;
+
 /* Function start: 0x42BDDB */
 signed char HasCutsceneMusicNode(CutsceneMusicNode *node)
 {
@@ -495,14 +505,20 @@ void AnimateCutsceneSpeakerMouth(SceneFlicObject *sprite)
         g_pszCutsceneSpeechCursor_00499eb0 = 0;
         return;
     }
-    if (g_bSpeechSoundActive_004a2660 == 0) {
+    if (g_bSpeechSoundActive_004a2660 != 0) {
+        g_bCutsceneSpeechAudioSeen = 1;
+    } else if (g_bCutsceneSpeechAudioSeen != 0) {
         /* Opcode 0x8a arms text-advance independently of when the paired
          * speech clip (opcode 0xb0) actually starts producing audio --
          * 0xb0's own cache miss falls back to a synchronous blocking disk
          * load (LoadAndPlaySpeechPacket, music.c). Hold the current frame
          * instead of animating from text alone until
          * g_bSpeechSoundActive_004a2660 is set, which happens only once
-         * real playback begins (PlayRawSpeechBuffer, sound.c). */
+         * real playback begins (PlayRawSpeechBuffer, sound.c). Only applies
+         * once this cutscene is known to have voice audio at all (see
+         * g_bCutsceneSpeechAudioSeen) -- most cutscenes have none, and
+         * text-driven animation with no audio to wait for is correct for
+         * those, same as the original engine always did. */
         return;
     }
     if (g_pSpeechSound_004a2658 != 0 &&
@@ -793,6 +809,24 @@ void RunLoadedCutscene(void)
     short savedInputPollPeriod;
     short savedMemoryStatus;
 
+    /* None of these are reset by the previous cutscene's own teardown
+     * (ReleaseCutsceneSpeechPackets only clears the precache slot
+     * arrays), so a cutscene torn down while its last line was still
+     * speaking leaves them stale here. ServiceSoundSystem (sound.c) keys
+     * its whole grace-period/mouth-reset/force-advance block on
+     * g_pSpeechSound_004a2658 alone being non-null -- it does not care
+     * whether THIS cutscene has any speech of its own -- so a stale
+     * pointer makes that block fight this cutscene's own (audio-less)
+     * mouth animation and force-advance its lines early. Dropping the
+     * reference here (not stopping or releasing the sound itself, which
+     * risks touching an already-freed object -- see the delete-on-stop
+     * comment in ServiceSoundSystem) is enough: if it is still genuinely
+     * playing, it finishes on its own and self-deletes via
+     * ix_sound_set_delete_on_stop, just no longer tracked here. */
+    g_pSpeechSound_004a2658 = 0;
+    g_bSpeechSoundActive_004a2660 = 0;
+    g_nSpeechCompletionDelay_004a265c = 0;
+    g_bCutsceneSpeechAudioSeen = 0;
     savedTextContext = g_pCurrentTextContext_005c8d1c;
     savedInputPollPeriod = g_nInputPollPeriod_0049d6d8;
     savedMemoryStatus = g_cShowMemoryStatus;

--- a/src/screens.c
+++ b/src/screens.c
@@ -495,6 +495,28 @@ void AnimateCutsceneSpeakerMouth(SceneFlicObject *sprite)
         g_pszCutsceneSpeechCursor_00499eb0 = 0;
         return;
     }
+    if (g_bSpeechSoundActive_004a2660 == 0) {
+        /* Script-armed to talk (opcode 0x8a sets
+         * g_bCutsceneTextAdvance_005d2ed0) but the paired speech clip
+         * (opcode 0xb0) hasn't actually started producing audio yet.
+         * These two are separate, unsynchronized script events -- 0xb0
+         * only reaches here without a delay when its pre-cache (opcode
+         * 0xa2, LoadCutsceneSpeechSlot) finished in time; otherwise it
+         * falls back to LoadAndPlaySpeechPacket (music.c), a fully
+         * synchronous blocking disk load with no message-pump
+         * interleaving of its own. A same-character line immediately
+         * following another leaves less script time for 0xa2 to have
+         * completed than a speaker change does, making this fallback
+         * (and this gap) far more likely there -- matching "mouth moves
+         * during a pause, but only between two lines from the same
+         * character" exactly. g_bSpeechSoundActive_004a2660 is set the
+         * moment real playback actually begins (PlayRawSpeechBuffer,
+         * sound.c) -- hold the current frame instead of animating from
+         * text alone until that's true.
+         * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
+         */
+        return;
+    }
     if (g_bCutsceneSkipFrame_00499c54 != 0 ||
         g_bCutsceneViewportPreallocated_00499c4c != 0) {
         g_bCutsceneSpeechActive_00499eb8 =

--- a/src/screens.c
+++ b/src/screens.c
@@ -2823,8 +2823,27 @@ handle_queued_cutscene_input:
         case 0x8f:
             value = *(short *)instruction;
             instruction += 2;
+            /* Was 0x3b (59) / value. g_nInputClock_005c84a8 (what this
+             * delay is measured against, see PumpWindowMessages/winmain.c)
+             * ticks in exact 1/60s units -- confirmed independently by
+             * WC2_CUTSCENE_MOUTH_MIN_TICKS=3 meaning exactly 3/60s=50ms=
+             * one 20fps frame elsewhere in this file. Converting a
+             * requested-fps `value` to a tick delay is 60/value, not
+             * 59/value; the sibling opcode 0x8d (above) takes an
+             * already-computed tick delay straight from the script with
+             * no arithmetic at all, so this is specifically the "set rate
+             * by fps" formula and nothing else. With integer division,
+             * 59/value truncates to a smaller (i.e. faster) delay than
+             * 60/value for nearly every value -- e.g. a scene requesting
+             * 20fps gets 59/20=2 ticks/frame (~30fps, 50% too fast)
+             * instead of the correct 60/20=3 (20fps). Different requested
+             * rates truncate by different amounts, which is consistent
+             * with cutscenes running at inconsistent, scene-dependent
+             * speeds rather than a single uniform offset.
+             * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
+             */
             g_nCutsceneFrameDelay_00499c8c =
-                (unsigned short)(0x3b / value);
+                (unsigned short)(0x3c / value);
             break;
         case 0x75:
             index = *instruction++;

--- a/src/screens.c
+++ b/src/screens.c
@@ -496,41 +496,23 @@ void AnimateCutsceneSpeakerMouth(SceneFlicObject *sprite)
         return;
     }
     if (g_bSpeechSoundActive_004a2660 == 0) {
-        /* Script-armed to talk (opcode 0x8a sets
-         * g_bCutsceneTextAdvance_005d2ed0) but the paired speech clip
-         * (opcode 0xb0) hasn't actually started producing audio yet.
-         * These two are separate, unsynchronized script events -- 0xb0
-         * only reaches here without a delay when its pre-cache (opcode
-         * 0xa2, LoadCutsceneSpeechSlot) finished in time; otherwise it
-         * falls back to LoadAndPlaySpeechPacket (music.c), a fully
-         * synchronous blocking disk load with no message-pump
-         * interleaving of its own. A same-character line immediately
-         * following another leaves less script time for 0xa2 to have
-         * completed than a speaker change does, making this fallback
-         * (and this gap) far more likely there -- matching "mouth moves
-         * during a pause, but only between two lines from the same
-         * character" exactly. g_bSpeechSoundActive_004a2660 is set the
-         * moment real playback actually begins (PlayRawSpeechBuffer,
-         * sound.c) -- hold the current frame instead of animating from
-         * text alone until that's true.
-         * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
-         */
+        /* Opcode 0x8a arms text-advance independently of when the paired
+         * speech clip (opcode 0xb0) actually starts producing audio --
+         * 0xb0's own cache miss falls back to a synchronous blocking disk
+         * load (LoadAndPlaySpeechPacket, music.c). Hold the current frame
+         * instead of animating from text alone until
+         * g_bSpeechSoundActive_004a2660 is set, which happens only once
+         * real playback begins (PlayRawSpeechBuffer, sound.c). */
         return;
     }
     if (g_pSpeechSound_004a2658 != 0 &&
         ix_sound_is_playing(g_pSpeechSound_004a2658) == 0) {
-        /* The other end of the same gap: g_bSpeechSoundActive_004a2660
-         * only clears once ServiceSoundSystem (sound.c) has waited out
-         * its own ~20-tick grace period after audio is first observed
-         * stopped -- that delay exists to decide when to force-advance
-         * to the next script line, not to decide whether the mouth
-         * should still be moving, but AnimateCutsceneSpeakerMouth was
-         * reading the same flag for both. Check the sound object's own
-         * live state directly instead: stop animating the instant
-         * playback actually stops, without waiting on or touching that
-         * unrelated grace-period/advance logic at all.
-         * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
-         */
+        /* g_bSpeechSoundActive_004a2660 clears only after
+         * ServiceSoundSystem's (sound.c) grace period, which exists to
+         * decide when to force-advance the script, not whether the mouth
+         * should keep moving. Check the sound object's own playing state
+         * directly instead, so the mouth stops the instant playback
+         * actually stops. */
         return;
     }
     if (g_bCutsceneSkipFrame_00499c54 != 0 ||

--- a/src/screens.c
+++ b/src/screens.c
@@ -517,6 +517,22 @@ void AnimateCutsceneSpeakerMouth(SceneFlicObject *sprite)
          */
         return;
     }
+    if (g_pSpeechSound_004a2658 != 0 &&
+        ix_sound_is_playing(g_pSpeechSound_004a2658) == 0) {
+        /* The other end of the same gap: g_bSpeechSoundActive_004a2660
+         * only clears once ServiceSoundSystem (sound.c) has waited out
+         * its own ~20-tick grace period after audio is first observed
+         * stopped -- that delay exists to decide when to force-advance
+         * to the next script line, not to decide whether the mouth
+         * should still be moving, but AnimateCutsceneSpeakerMouth was
+         * reading the same flag for both. Check the sound object's own
+         * live state directly instead: stop animating the instant
+         * playback actually stops, without waiting on or touching that
+         * unrelated grace-period/advance logic at all.
+         * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
+         */
+        return;
+    }
     if (g_bCutsceneSkipFrame_00499c54 != 0 ||
         g_bCutsceneViewportPreallocated_00499c4c != 0) {
         g_bCutsceneSpeechActive_00499eb8 =

--- a/src/sound.c
+++ b/src/sound.c
@@ -262,8 +262,17 @@ void ServiceSoundSystem(void)
                     g_bCutsceneSpeechActive_00499eb8 = 0;
                     g_bCutsceneTextAdvance_005d2ed0 = 0;
                     g_pszCutsceneSpeechCursor_00499eb0 = 0;
-                    if (g_pCurrentCutsceneSprite_00499c78 != 0)
-                        g_pCurrentCutsceneSprite_00499c78->currentFrame = 11;
+                    /* g_pCurrentCutsceneSprite_00499c78 is whichever
+                     * object happens to be executing its own script
+                     * opcodes at the moment this runs (set/restored
+                     * around every sprite/plane's dispatch) -- not
+                     * necessarily the speaker. g_pLinkedCutsceneSprite_
+                     * 00499c64 is the sprite opcode 0x8a actually armed
+                     * for mouth animation, the same one
+                     * AnimateCutsceneSpeakerMouth (screens.c) itself
+                     * resets to frame 11 on its own early-return paths. */
+                    if (g_pLinkedCutsceneSprite_00499c64 != 0)
+                        g_pLinkedCutsceneSprite_00499c64->currentFrame = 11;
                 }
             }
             g_nSpeechCompletionDelay_004a265c++;

--- a/src/sound.c
+++ b/src/sound.c
@@ -238,53 +238,60 @@ void ServiceSoundSystem(void)
 #endif
         if (g_pSpeechSound_004a2658 != 0 &&
             ix_sound_is_playing(g_pSpeechSound_004a2658) == 0 &&
-            g_bSpeechSoundActive_004a2660 != 0) {
-            g_nSpeechCompletionDelay_004a265c++;
-            if (g_bSpaceFlightActive_005c586c != 0) {
-                g_bSpeechPlaybackComplete_004a266c = 1;
-                g_bSpeechSoundActive_004a2660 = 0;
-            }
-            if (g_nSpeechCompletionDelay_004a265c > 20) {
-                if (g_bSpaceFlightActive_005c586c == 0)
-                    g_nInputPressCount_0049c258 = 1;
+            g_nSpeechCompletionDelay_004a265c <= 20) {
+            /* Outer condition was g_bSpeechSoundActive_004a2660 != 0, which
+             * this branch itself used to clear only past the >20 check
+             * below -- a one-shot re-entry gate that this rewrite
+             * preserves via g_nSpeechCompletionDelay_004a265c instead (it
+             * resets to 0 in PlayRawSpeechSound whenever a genuinely new
+             * clip starts, same as g_bSpeechSoundActive_004a2660 did, so
+             * this stays equivalent for that purpose). Freed up because
+             * the mouth/script reset below now needs to fire on the FIRST
+             * frame audio is observed stopped, not the 21st, without
+             * changing when g_nInputPressCount_0049c258 fires below --
+             * see that reset's own comment for why. */
+            if (g_nSpeechCompletionDelay_004a265c == 0) {
+                /* Was SetCinematicFrameTiming(70.0f), then (in an earlier
+                 * revision of this fix) the same reset as below but only
+                 * once this whole function had already waited out the
+                 * full 20-tick grace period before running it. That
+                 * grace period exists to decide when to force-advance to
+                 * the next script line (g_nInputPressCount_0049c258
+                 * below) if nothing else happens -- it has nothing to do
+                 * with the mouth, but both were gated on the same
+                 * countdown. The cutscene script itself directly reads
+                 * g_bCutsceneTextAdvance_005d2ed0 (opcode 0x9c,
+                 * PushCutsceneScriptValue, screens.c) to know when
+                 * speech has finished, almost certainly in a "wait while
+                 * still talking" loop before advancing to the next
+                 * line -- so leaving this flag set for the full grace
+                 * period didn't just leave the mouth animating too long
+                 * (already fixed, see AnimateCutsceneSpeakerMouth), it
+                 * also blocked the *next line itself* from starting for
+                 * that same ~20-tick window, worst-case (and most
+                 * visible) whenever pre-caching left no other script
+                 * work to cover it -- i.e. consecutive lines from the
+                 * same character. Doing this reset the instant audio is
+                 * observed stopped, instead of waiting for the grace
+                 * period even that far, removes that delay too.
+                 * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
+                 */
                 g_bSpeechSoundActive_004a2660 = 0;
                 if (g_bSpaceFlightActive_005c586c == 0) {
-                    /* Was SetCinematicFrameTiming(70.0f). That call is not
-                     * an isolated bug -- it exists to paper over a real
-                     * problem: AnimateCutsceneSpeakerMouth (screens.c)
-                     * drives the mouth from the caption TEXT, at its own
-                     * per-letter pace, completely independent of how long
-                     * the actual speech audio clip runs. If the audio
-                     * (real recorded VO on this Kilrathi Saga release,
-                     * unlike the DOS original's synthesized speech) is
-                     * shorter than the text still has left to animate,
-                     * the mouth keeps moving with no sound playing --
-                     * this is the exact "waited 20 service calls, audio's
-                     * definitely done" branch that detects that state.
-                     * The original fix was to spike the frame rate 3.5x
-                     * to rush through the remaining text faster, since
-                     * mouth state only advances when a frame renders (see
-                     * the docs cited below) -- treating the symptom, not
-                     * the cause, and badly: it also speeds up every other
-                     * sprite/plane/sequence on screen for that window, not
-                     * just the mouth.
-                     *
-                     * Root-cause fix: stop the mouth directly instead.
-                     * This is the exact reset AnimateCutsceneSpeakerMouth
-                     * already performs on its own once it notices speech
-                     * is inactive (g_wSpeechCacheState_0049bb60 == 0) --
-                     * forcing it here means it happens the instant this
-                     * function decides speech has truly ended, not
-                     * whenever the mouth-text finally catches up on its
-                     * own pace.
-                     * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
-                     */
                     g_bCutsceneSpeechActive_00499eb8 = 0;
                     g_bCutsceneTextAdvance_005d2ed0 = 0;
                     g_pszCutsceneSpeechCursor_00499eb0 = 0;
                     if (g_pCurrentCutsceneSprite_00499c78 != 0)
                         g_pCurrentCutsceneSprite_00499c78->currentFrame = 11;
                 }
+            }
+            g_nSpeechCompletionDelay_004a265c++;
+            if (g_bSpaceFlightActive_005c586c != 0) {
+                g_bSpeechPlaybackComplete_004a266c = 1;
+            }
+            if (g_nSpeechCompletionDelay_004a265c > 20) {
+                if (g_bSpaceFlightActive_005c586c == 0)
+                    g_nInputPressCount_0049c258 = 1;
             }
         }
     }

--- a/src/sound.c
+++ b/src/sound.c
@@ -248,27 +248,43 @@ void ServiceSoundSystem(void)
                 if (g_bSpaceFlightActive_005c586c == 0)
                     g_nInputPressCount_0049c258 = 1;
                 g_bSpeechSoundActive_004a2660 = 0;
-                if (g_bSpaceFlightActive_005c586c == 0)
-                    /* Was SetCinematicFrameTiming(70.0f). 70fps appears
-                     * nowhere else in the engine and is a ~3.5x spike over
-                     * the 20fps rate PlayRawSpeechSound sets when speech
-                     * starts (this same file, above). Cutscene mouth timing
-                     * (AnimateCutsceneSpeakerMouth, screens.c) holds each
-                     * shape for as little as 1/60s -- already shorter than
-                     * one 20fps frame -- against a clock resynced every
-                     * frame to real elapsed time, so mouth state advances
-                     * at whatever rate frames actually render, not at its
-                     * authored rate. A frame-rate spike exactly when speech
-                     * ends is the worst possible moment for that: mouth
-                     * state races far ahead of the (already-stopped, but
-                     * still audibly trailing) speech audio right as it
-                     * needs to settle back to neutral. Holding the rate
-                     * steady through this transition removes that spike;
-                     * it does not by itself fix the underlying sub-frame
-                     * duration issue (see the docs cited below).
+                if (g_bSpaceFlightActive_005c586c == 0) {
+                    /* Was SetCinematicFrameTiming(70.0f). That call is not
+                     * an isolated bug -- it exists to paper over a real
+                     * problem: AnimateCutsceneSpeakerMouth (screens.c)
+                     * drives the mouth from the caption TEXT, at its own
+                     * per-letter pace, completely independent of how long
+                     * the actual speech audio clip runs. If the audio
+                     * (real recorded VO on this Kilrathi Saga release,
+                     * unlike the DOS original's synthesized speech) is
+                     * shorter than the text still has left to animate,
+                     * the mouth keeps moving with no sound playing --
+                     * this is the exact "waited 20 service calls, audio's
+                     * definitely done" branch that detects that state.
+                     * The original fix was to spike the frame rate 3.5x
+                     * to rush through the remaining text faster, since
+                     * mouth state only advances when a frame renders (see
+                     * the docs cited below) -- treating the symptom, not
+                     * the cause, and badly: it also speeds up every other
+                     * sprite/plane/sequence on screen for that window, not
+                     * just the mouth.
+                     *
+                     * Root-cause fix: stop the mouth directly instead.
+                     * This is the exact reset AnimateCutsceneSpeakerMouth
+                     * already performs on its own once it notices speech
+                     * is inactive (g_wSpeechCacheState_0049bb60 == 0) --
+                     * forcing it here means it happens the instant this
+                     * function decides speech has truly ended, not
+                     * whenever the mouth-text finally catches up on its
+                     * own pace.
                      * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
                      */
-                    SetCinematicFrameTiming(20.0f);
+                    g_bCutsceneSpeechActive_00499eb8 = 0;
+                    g_bCutsceneTextAdvance_005d2ed0 = 0;
+                    g_pszCutsceneSpeechCursor_00499eb0 = 0;
+                    if (g_pCurrentCutsceneSprite_00499c78 != 0)
+                        g_pCurrentCutsceneSprite_00499c78->currentFrame = 11;
+                }
             }
         }
     }

--- a/src/sound.c
+++ b/src/sound.c
@@ -249,7 +249,26 @@ void ServiceSoundSystem(void)
                     g_nInputPressCount_0049c258 = 1;
                 g_bSpeechSoundActive_004a2660 = 0;
                 if (g_bSpaceFlightActive_005c586c == 0)
-                    SetCinematicFrameTiming(70.0f);
+                    /* Was SetCinematicFrameTiming(70.0f). 70fps appears
+                     * nowhere else in the engine and is a ~3.5x spike over
+                     * the 20fps rate PlayRawSpeechSound sets when speech
+                     * starts (this same file, above). Cutscene mouth timing
+                     * (AnimateCutsceneSpeakerMouth, screens.c) holds each
+                     * shape for as little as 1/60s -- already shorter than
+                     * one 20fps frame -- against a clock resynced every
+                     * frame to real elapsed time, so mouth state advances
+                     * at whatever rate frames actually render, not at its
+                     * authored rate. A frame-rate spike exactly when speech
+                     * ends is the worst possible moment for that: mouth
+                     * state races far ahead of the (already-stopped, but
+                     * still audibly trailing) speech audio right as it
+                     * needs to settle back to neutral. Holding the rate
+                     * steady through this transition removes that spike;
+                     * it does not by itself fix the underlying sub-frame
+                     * duration issue (see the docs cited below).
+                     * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
+                     */
+                    SetCinematicFrameTiming(20.0f);
             }
         }
     }

--- a/src/sound.c
+++ b/src/sound.c
@@ -231,51 +231,32 @@ void ServiceSoundSystem(void)
     if (g_nAudioEnabled_0049c244 != 0) {
         ix_system_service_sounds();
 #ifdef WC1_SDL
-        /* The speech sound is created delete-on-stop, so the call above can
-         * have freed it; the original read the dead block anyway. */
-        if (!ix_sound_is_live(g_pSpeechSound_004a2658))
-            g_pSpeechSound_004a2658 = 0;
+        /* The speech sound is delete-on-stop, so the call above can have
+         * freed it already this frame. Evaluate liveness into a local
+         * before touching g_pSpeechSound_004a2658, so a same-frame free
+         * still runs the stopped-handling block below instead of being
+         * skipped because the pointer already reads as 0. */
+        int speechIsLive = g_pSpeechSound_004a2658 != 0 &&
+                            ix_sound_is_live(g_pSpeechSound_004a2658);
+#else
+        int speechIsLive = 1;
 #endif
         if (g_pSpeechSound_004a2658 != 0 &&
-            ix_sound_is_playing(g_pSpeechSound_004a2658) == 0 &&
+            (!speechIsLive || ix_sound_is_playing(g_pSpeechSound_004a2658) == 0) &&
             g_nSpeechCompletionDelay_004a265c <= 20) {
-            /* Outer condition was g_bSpeechSoundActive_004a2660 != 0, which
-             * this branch itself used to clear only past the >20 check
-             * below -- a one-shot re-entry gate that this rewrite
-             * preserves via g_nSpeechCompletionDelay_004a265c instead (it
-             * resets to 0 in PlayRawSpeechSound whenever a genuinely new
-             * clip starts, same as g_bSpeechSoundActive_004a2660 did, so
-             * this stays equivalent for that purpose). Freed up because
-             * the mouth/script reset below now needs to fire on the FIRST
-             * frame audio is observed stopped, not the 21st, without
-             * changing when g_nInputPressCount_0049c258 fires below --
-             * see that reset's own comment for why. */
+            /* g_nSpeechCompletionDelay_004a265c gates re-entry instead of
+             * g_bSpeechSoundActive_004a2660: it resets to 0 in
+             * PlayRawSpeechBuffer whenever a new clip starts, so this
+             * block still only fires once per stopped clip, but the reset
+             * below can run on the first frame audio is observed stopped
+             * rather than waiting for the full grace period. */
             if (g_nSpeechCompletionDelay_004a265c == 0) {
-                /* Was SetCinematicFrameTiming(70.0f), then (in an earlier
-                 * revision of this fix) the same reset as below but only
-                 * once this whole function had already waited out the
-                 * full 20-tick grace period before running it. That
-                 * grace period exists to decide when to force-advance to
-                 * the next script line (g_nInputPressCount_0049c258
-                 * below) if nothing else happens -- it has nothing to do
-                 * with the mouth, but both were gated on the same
-                 * countdown. The cutscene script itself directly reads
-                 * g_bCutsceneTextAdvance_005d2ed0 (opcode 0x9c,
-                 * PushCutsceneScriptValue, screens.c) to know when
-                 * speech has finished, almost certainly in a "wait while
-                 * still talking" loop before advancing to the next
-                 * line -- so leaving this flag set for the full grace
-                 * period didn't just leave the mouth animating too long
-                 * (already fixed, see AnimateCutsceneSpeakerMouth), it
-                 * also blocked the *next line itself* from starting for
-                 * that same ~20-tick window, worst-case (and most
-                 * visible) whenever pre-caching left no other script
-                 * work to cover it -- i.e. consecutive lines from the
-                 * same character. Doing this reset the instant audio is
-                 * observed stopped, instead of waiting for the grace
-                 * period even that far, removes that delay too.
-                 * https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md
-                 */
+                /* The cutscene script polls g_bCutsceneTextAdvance_005d2ed0
+                 * (opcode 0x9c, screens.c) to know when speech has
+                 * finished before advancing to the next line, so clearing
+                 * these here -- immediately on stop, not after the grace
+                 * period below -- keeps both the mouth and the next
+                 * line's start in sync with when audio actually ends. */
                 g_bSpeechSoundActive_004a2660 = 0;
                 if (g_bSpaceFlightActive_005c586c == 0) {
                     g_bCutsceneSpeechActive_00499eb8 = 0;
@@ -294,6 +275,10 @@ void ServiceSoundSystem(void)
                     g_nInputPressCount_0049c258 = 1;
             }
         }
+#ifdef WC1_SDL
+        if (!speechIsLive)
+            g_pSpeechSound_004a2658 = 0;
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2 (cutscene/animation playback too fast) as far as the
mouth/speech-timing side of it goes, plus the mouth/audio desync this
investigation started from. Full writeup with root-cause tracing for
each fix: https://github.com/schlangz/openwc2/blob/main/docs/wc2re_cross_reference.md

Ten focused commits, each independently reasoned about and (except
the last) confirmed in-game against real playback before moving to
the next:

- Replace the `SetCinematicFrameTiming(70.0f)` speech-completion
  spike with a direct mouth/state reset -- the spike was a symptom
  patch (rushing text-driven mouth animation to catch up to already-
  finished audio) rather than a fix for the actual cause.
- Correct cutscene script opcode `0x8f`'s fps-to-tick-delay divisor
  (`0x3b` -> `0x3c`, i.e. 59 -> 60) -- `g_nInputClock` ticks in exact
  1/60s units, so the old divisor made every requested framerate
  round down to a faster-than-intended tick delay.
- Gate mouth animation on `g_bSpeechSoundActive_004a2660` so it
  doesn't start (or keep running) ahead of/behind the audio it's
  meant to lip-sync -- opcodes `0x8a` (arm) and `0xb0` (play) are
  unsynchronized script events with no inherent ordering guarantee.
- Move the flag/sprite reset in `ServiceSoundSystem` to fire the
  instant audio is observed stopped, instead of after its own
  20-tick grace period -- that period exists to decide when to
  force-advance the script if nothing else happens, not to decide
  whether the mouth should still be animating or the next line
  blocked from starting.
- Fix a same-frame race in the delete-on-stop liveness check that
  could skip the above reset entirely when the sound was freed the
  same frame it stopped, leaving the next line's mouth pre-armed
  before its own audio had even started.
- Reset the *armed speaker's* frame on speech-stop
  (`g_pLinkedCutsceneSprite_00499c64`) instead of whatever object
  happens to be mid-script at that moment
  (`g_pCurrentCutsceneSprite_00499c78`) -- the latter isn't specific
  to the speaker and was rewinding unrelated sprites' animations
  (e.g. a hand-raise gesture replaying) when it happened to be
  active at the wrong moment.
- Stop gating mouth animation on audio for cutscenes that have no
  audio at all -- most cutscenes have none, and the audio-active gate
  above froze their mouths permanently. Track whether real speech has
  ever actually played in the current cutscene and only gate once it
  has.
- Reset the speech-sound state at the top of every cutscene --
  none of it is cleared by the previous cutscene's own teardown, so
  one torn down mid-speech left stale state that made
  `ServiceSoundSystem` fight an unrelated, audio-less cutscene's own
  mouth animation and force-advance its lines early.
- Raise the unvoiced-line mouth-pacing floor (`WC2_CUTSCENE_MOUTH_MIN_TICKS`)
  from 3 to 6 ticks -- it was tuned only against the voiced-line case
  (where real audio length dominates pacing regardless of this
  floor's exact value), but it's the *entire* pacing mechanism for
  unvoiced lines, and 3 measured twice too fast there in direct
  in-game comparison.

## Test plan

- [x] Each commit syntax-checked with the project's real
      `MODERN_CFLAGS`/`MODERN_CXXFLAGS`/`MODERN_CPPFLAGS`
      (`-std=c11`/`-std=c++17`, `-DWC1_SDL=1`)
- [x] Confirmed in-game against real cutscene playback across several
      rounds of testing (mouth/audio sync on voiced lines, mouth
      pacing on unvoiced lines, no regressions to background music or
      unrelated sprite animation)
- [ ] Broader playthrough coverage beyond what's been directly tested
      would still be useful before merging