### PR TITLE
fix: correct output aspect ratio to 4:3

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -23,15 +23,6 @@ int Wc1SdlInitializeVideo(SDL_Window *window)
             SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
     if (g_pSdlRenderer == 0)
         return 0;
-    if (SDL_RenderSetLogicalSize(g_pSdlRenderer, WC1_SDL_FRAME_WIDTH,
-                                 WC1_SDL_FRAME_HEIGHT) != 0) {
-        Wc1SdlShutdownVideo();
-        return 0;
-    }
-    if (SDL_RenderSetIntegerScale(g_pSdlRenderer, SDL_TRUE) != 0) {
-        Wc1SdlShutdownVideo();
-        return 0;
-    }
     g_pSdlFrameTexture =
         SDL_CreateTexture(g_pSdlRenderer, SDL_PIXELFORMAT_ARGB8888,
                           SDL_TEXTUREACCESS_STREAMING,
@@ -44,6 +35,26 @@ int Wc1SdlInitializeVideo(SDL_Window *window)
     SDL_SetRenderDrawColor(g_pSdlRenderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(g_pSdlRenderer);
     SDL_RenderPresent(g_pSdlRenderer);
+    return 1;
+}
+
+/* No longer relies on SDL_RenderSetLogicalSize -- that letterboxes to
+ * the source frame's own 320x200 (8:5) shape, not the 4:3 shape the
+ * game was actually displayed at on period CRT hardware (see the
+ * comment on Wc1SdlCalculateOutputViewport, video_state.c). Computed
+ * fresh each frame since the window can be resized. */
+static int Wc1SdlComputeFrameDestRect(SDL_Rect *dest)
+{
+    int bottom;
+    int height;
+    int width;
+
+    if (SDL_GetRendererOutputSize(g_pSdlRenderer, &width, &height) != 0 ||
+        width < 1 || height < 1)
+        return 0;
+    Wc1SdlCalculateOutputViewport(width, height, &dest->x, &bottom, &dest->w,
+                                  &dest->h);
+    dest->y = height - bottom - dest->h;
     return 1;
 }
 
@@ -63,12 +74,13 @@ void Wc1SdlShutdownVideo(void)
 int Wc1SdlPresentIndexedFrame(const unsigned char *pixels,
                               const unsigned char *palette)
 {
+    SDL_Rect dest;
     int pixel;
 
     if (Wc1SdlUsingGlRenderer())
         return Wc1SdlGlRendererPresent(pixels, palette);
     if (g_pSdlRenderer == 0 || g_pSdlFrameTexture == 0 || pixels == 0 ||
-        palette == 0)
+        palette == 0 || !Wc1SdlComputeFrameDestRect(&dest))
         return 0;
     pixel = 0;
     while (pixel < WC1_SDL_FRAME_WIDTH * WC1_SDL_FRAME_HEIGHT) {
@@ -90,7 +102,7 @@ int Wc1SdlPresentIndexedFrame(const unsigned char *pixels,
         return 0;
     if (SDL_RenderClear(g_pSdlRenderer) != 0)
         return 0;
-    if (SDL_RenderCopy(g_pSdlRenderer, g_pSdlFrameTexture, 0, 0) != 0)
+    if (SDL_RenderCopy(g_pSdlRenderer, g_pSdlFrameTexture, 0, &dest) != 0)
         return 0;
     SDL_RenderPresent(g_pSdlRenderer);
     return 1;
@@ -98,6 +110,8 @@ int Wc1SdlPresentIndexedFrame(const unsigned char *pixels,
 
 void Wc1SdlWaitForVerticalBlank(void)
 {
+    SDL_Rect dest;
+
     if (Wc1SdlUsingGlRenderer()) {
         Wc1SdlGlRendererWaitForVerticalBlank();
         return;
@@ -107,7 +121,8 @@ void Wc1SdlWaitForVerticalBlank(void)
         return;
     }
     SDL_RenderClear(g_pSdlRenderer);
-    SDL_RenderCopy(g_pSdlRenderer, g_pSdlFrameTexture, 0, 0);
+    if (Wc1SdlComputeFrameDestRect(&dest))
+        SDL_RenderCopy(g_pSdlRenderer, g_pSdlFrameTexture, 0, &dest);
     SDL_RenderPresent(g_pSdlRenderer);
 }
 

--- a/src/sdl/video_state.c
+++ b/src/sdl/video_state.c
@@ -55,21 +55,23 @@ void Wc1SdlCalculateOutputViewport(int width, int height, int *left,
                                    int *bottom, int *viewportWidth,
                                    int *viewportHeight)
 {
-    int scale;
-    double fractionalScale;
-
-    scale = width / WC1_SDL_FRAME_WIDTH;
-    if (height / WC1_SDL_FRAME_HEIGHT < scale)
-        scale = height / WC1_SDL_FRAME_HEIGHT;
-    if (scale >= 1) {
-        *viewportWidth = WC1_SDL_FRAME_WIDTH * scale;
-        *viewportHeight = WC1_SDL_FRAME_HEIGHT * scale;
+    /* Target a 4:3 output, not the source frame's own 320x200 (8:5)
+     * shape. 320x200 is square-pixel VGA Mode 13h; the original game
+     * was always displayed on 4:3 CRT hardware, which rendered it with
+     * non-square pixels (taller than wide) to fill that shape. Scaling
+     * width and height by the same factor -- as this used to, to keep
+     * the source's own 8:5 ratio and land on an exact integer multiple
+     * of it -- reproduces the square-pixel shape instead, which comes
+     * out visibly wider/flatter than the original ever looked. Fit the
+     * largest 4:3 rectangle inside (width, height) instead; this can't
+     * be an exact integer multiple of 320x200 in both axes at once,
+     * since 320x200 itself isn't 4:3. */
+    if (width * 3 > height * 4) {
+        *viewportHeight = height;
+        *viewportWidth = height * 4 / 3;
     } else {
-        fractionalScale = (double)width / WC1_SDL_FRAME_WIDTH;
-        if ((double)height / WC1_SDL_FRAME_HEIGHT < fractionalScale)
-            fractionalScale = (double)height / WC1_SDL_FRAME_HEIGHT;
-        *viewportWidth = (int)(WC1_SDL_FRAME_WIDTH * fractionalScale);
-        *viewportHeight = (int)(WC1_SDL_FRAME_HEIGHT * fractionalScale);
+        *viewportWidth = width;
+        *viewportHeight = width * 3 / 4;
     }
     if (*viewportWidth < 1)
         *viewportWidth = 1;
@@ -89,12 +91,10 @@ static int Wc1SdlGetWindowViewport(SDL_Window *window, int *left, int *top,
     SDL_GetWindowSize(window, &width, &height);
     if (width < 1 || height < 1)
         return 0;
-    *left = 0;
-    *top = 0;
-    *viewportWidth = width;
-    *viewportHeight = height;
-    if (!Wc1SdlUsingGlRenderer())
-        return 1;
+    /* Both backends now present into a manually computed 4:3 rect
+     * (video.c/gl_renderer.c) rather than relying on SDL_RenderSet
+     * LogicalSize's own native-320x200-aspect letterboxing, so mouse
+     * mapping needs the same 4:3 calculation for both, not just GL. */
     Wc1SdlCalculateOutputViewport(width, height, left, &bottom,
                                   viewportWidth, viewportHeight);
     *top = height - bottom - *viewportHeight;
@@ -104,20 +104,18 @@ static int Wc1SdlGetWindowViewport(SDL_Window *window, int *left, int *top,
 int Wc1SdlMapLogicalToWindow(SDL_Window *window, int logicalX, int logicalY,
                              int *windowX, int *windowY)
 {
-    SDL_Renderer *renderer;
     int viewportHeight;
     int viewportLeft;
     int viewportTop;
     int viewportWidth;
 
+    /* Both backends present into a manually computed 4:3 rect (see
+     * Wc1SdlGetWindowViewport) rather than an SDL_Renderer logical size,
+     * so SDL_RenderLogicalToWindow no longer has the right transform to
+     * ask even when a renderer exists -- always use the same viewport
+     * calculation the frame itself was drawn into. */
     if (window == 0 || windowX == 0 || windowY == 0)
         return 0;
-    renderer = SDL_GetRenderer(window);
-    if (renderer != 0) {
-        SDL_RenderLogicalToWindow(renderer, (float)logicalX, (float)logicalY,
-                                  windowX, windowY);
-        return 1;
-    }
     if (!Wc1SdlGetWindowViewport(window, &viewportLeft, &viewportTop,
                                  &viewportWidth, &viewportHeight))
         return 0;
@@ -129,9 +127,6 @@ int Wc1SdlMapLogicalToWindow(SDL_Window *window, int logicalX, int logicalY,
 int Wc1SdlMapWindowToLogical(SDL_Window *window, int windowX, int windowY,
                              int *logicalX, int *logicalY)
 {
-    SDL_Renderer *renderer;
-    float mappedX;
-    float mappedY;
     int viewportHeight;
     int viewportLeft;
     int viewportTop;
@@ -139,14 +134,6 @@ int Wc1SdlMapWindowToLogical(SDL_Window *window, int windowX, int windowY,
 
     if (window == 0 || logicalX == 0 || logicalY == 0)
         return 0;
-    renderer = SDL_GetRenderer(window);
-    if (renderer != 0) {
-        SDL_RenderWindowToLogical(renderer, windowX, windowY, &mappedX,
-                                  &mappedY);
-        *logicalX = (int)mappedX;
-        *logicalY = (int)mappedY;
-        return 1;
-    }
     if (!Wc1SdlGetWindowViewport(window, &viewportLeft, &viewportTop,
                                  &viewportWidth, &viewportHeight))
         return 0;


### PR DESCRIPTION
## Summary

Fixes #12.

`WC1_SDL_FRAME_WIDTH`/`HEIGHT` are 320x200 -- classic VGA Mode 13h.
That resolution has a native square-pixel ratio of 1.6:1 (8:5), not
4:3 (1.333:1). Real DOS-era hardware displayed 320x200 on 4:3 CRT
monitors using non-square pixels (each pixel drawn taller than wide)
to stretch it to fill a 4:3 screen -- the game's art was always
designed around that stretch, not around square pixels.

`Wc1SdlCalculateOutputViewport` (`src/sdl/video_state.c`) applied one
uniform scale factor to both width and height, which preserves
320:200's own native ratio instead of correcting it -- everything
rendered visibly wider/flatter than it looked on period-correct
hardware.

- `Wc1SdlCalculateOutputViewport` now fits the largest 4:3 rectangle
  inside the window instead. The GL backend (`gl_renderer.c`) needed
  no changes -- it already draws both the base frame and
  space-flight sprites through one shared GL viewport built from this
  function's output, so the correction applies to both consistently
  for free (verified by tracing the sprite-vertex math: sprites are
  positioned in logical 320x200 space and scaled entirely by that
  viewport transform).
- The default (non-GL) backend previously relied on
  `SDL_RenderSetLogicalSize`/`SDL_RenderSetIntegerScale`, which only
  know how to preserve a texture's own native aspect ratio and can't
  express this correction. Replaced with a per-frame destination rect
  computed via the same viewport function the GL path uses.
- Mouse coordinate mapping (`Wc1SdlMapLogicalToWindow`/
  `WindowToLogical`) previously used
  `SDL_RenderLogicalToWindow`/`WindowToLogical` for the default
  backend, which assumed the now-removed logical-size setup; both
  directions now go through the same corrected viewport calculation
  as the frame itself for both backends, so clicks stay aligned with
  the corrected image.

Since 320x200 can't be an exact integer multiple of a 4:3 target, this
necessarily uses non-uniform (and generally non-integer) scaling --
the same trade-off DOSBox's own aspect-correction feature makes; an
expected cost of getting the shape right, not a bug.

## Test plan

- [x] `video.c`, `video_state.c`, and `gl_renderer.c` all syntax-check
      clean with the project's real `MODERN_CFLAGS`/`MODERN_CPPFLAGS`
- [x] Confirmed in-game: output now renders at correct 4:3 proportions
- [ ] Mouse click alignment across both backends (default and GL
      "sharp bilinear") could use broader testing beyond what's been
      directly checked so far