### PR TITLE
Floor short cutscene sprite/plane waits so debris doesn't race the host

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -100,6 +100,15 @@ typedef unsigned int DwordPtr;
  * unvoiced case; not derived from a DOS trace. */
 #define CUTSCENE_MOUTH_MIN_TICKS 6
 
+/* Same class of bug as CUTSCENE_MOUTH_MIN_TICKS above, but for the general
+ * sprite/plane wait opcodes (0x44, 0xaa) that every cutscene object -- not
+ * just the speaker's mouth -- uses to pace its own script. A script-authored
+ * wait of a tick or two relied on the DOS host's own draw speed to look
+ * right; the port's clock gate can resolve it dozens of times a second.
+ * Starting from the mouth's proven value as a first guess, not tuned
+ * separately yet. */
+#define CUTSCENE_SPRITE_MIN_TICKS 6
+
 /* Marks a routine that deliberately indexes out of one global and into the one
  * that follows it.  The original's data layout is what makes those reads land
  * where they are meant to, and the reconstruction reproduces that layout

--- a/src/screens.c
+++ b/src/screens.c
@@ -1261,13 +1261,6 @@ void UpdateCutscenePlaneObject(CutscenePlane *plane,
             g_nInputClock_005c84a8 < plane->waitStart + plane->waitTicks) {
             waiting = 1;
         } else {
-#ifdef SDL_PORT
-            SdlTracef("[plane-wait] expired plane=%p wanted=%d "
-                         "actual=%d clock=%d\n",
-                         (void *)plane, (int)plane->waitTicks,
-                         (int)(g_nInputClock_005c84a8 - plane->waitStart),
-                         (int)g_nInputClock_005c84a8);
-#endif
             plane->waitTicks = 0;
         }
     }
@@ -1309,14 +1302,6 @@ void UpdateCutsceneSpriteObject(SceneFlicObject *sprite)
             g_nInputClock_005c84a8 < sprite->waitStart + sprite->waitTicks) {
             waiting++;
         } else {
-#ifdef SDL_PORT
-            SdlTracef("[sprite-wait] expired sprite=%p frame=%d wanted=%d "
-                         "actual=%d clock=%d\n",
-                         (void *)sprite, (int)sprite->currentFrame,
-                         (int)sprite->waitTicks,
-                         (int)(g_nInputClock_005c84a8 - sprite->waitStart),
-                         (int)g_nInputClock_005c84a8);
-#endif
             sprite->waitTicks = 0;
         }
     }

--- a/src/screens.c
+++ b/src/screens.c
@@ -1261,6 +1261,13 @@ void UpdateCutscenePlaneObject(CutscenePlane *plane,
             g_nInputClock_005c84a8 < plane->waitStart + plane->waitTicks) {
             waiting = 1;
         } else {
+#ifdef SDL_PORT
+            SdlTracef("[plane-wait] expired plane=%p wanted=%d "
+                         "actual=%d clock=%d\n",
+                         (void *)plane, (int)plane->waitTicks,
+                         (int)(g_nInputClock_005c84a8 - plane->waitStart),
+                         (int)g_nInputClock_005c84a8);
+#endif
             plane->waitTicks = 0;
         }
     }
@@ -1302,6 +1309,14 @@ void UpdateCutsceneSpriteObject(SceneFlicObject *sprite)
             g_nInputClock_005c84a8 < sprite->waitStart + sprite->waitTicks) {
             waiting++;
         } else {
+#ifdef SDL_PORT
+            SdlTracef("[sprite-wait] expired sprite=%p frame=%d wanted=%d "
+                         "actual=%d clock=%d\n",
+                         (void *)sprite, (int)sprite->currentFrame,
+                         (int)sprite->waitTicks,
+                         (int)(g_nInputClock_005c84a8 - sprite->waitStart),
+                         (int)g_nInputClock_005c84a8);
+#endif
             sprite->waitTicks = 0;
         }
     }
@@ -2176,9 +2191,25 @@ handle_queued_cutscene_input:
             waitTicks = PopCutsceneScriptValue(&stack, stackStorage + 10);
             if (g_bCutsceneSkipFrame_00499c54 != 0)
                 waitTicks = 0;
+#ifdef SDL_PORT
+            /* See CUTSCENE_SPRITE_MIN_TICKS: a short script-authored wait
+             * relied on the DOS host's own draw speed, not a real-time
+             * gate, to look right. */
+            if (waitTicks != 0 && waitTicks < CUTSCENE_SPRITE_MIN_TICKS)
+                waitTicks = CUTSCENE_SPRITE_MIN_TICKS;
+#endif
             g_pCurrentCutsceneSprite_00499c78->waitTicks = waitTicks;
             g_pCurrentCutsceneSprite_00499c78->waitStart =
                 g_nInputClock_005c84a8;
+#ifdef SDL_PORT
+            SdlTracef("[sprite-wait] op=0x44 sprite=%p frame=%d x=%d y=%d "
+                         "wait=%d clock=%d\n",
+                         (void *)g_pCurrentCutsceneSprite_00499c78,
+                         (int)g_pCurrentCutsceneSprite_00499c78->currentFrame,
+                         (int)g_pCurrentCutsceneSprite_00499c78->x,
+                         (int)g_pCurrentCutsceneSprite_00499c78->y,
+                         (int)waitTicks, (int)g_nInputClock_005c84a8);
+#endif
             if (objectType == 0) {
                 *scriptCursor = instruction;
                 return returnValue;
@@ -2334,9 +2365,24 @@ handle_queued_cutscene_input:
             waitTicks = PopCutsceneScriptValue(&stack, stackStorage + 10);
             if (g_bCutsceneSkipFrame_00499c54 != 0)
                 waitTicks = 0;
+#ifdef SDL_PORT
+            /* See CUTSCENE_SPRITE_MIN_TICKS: a short script-authored wait
+             * relied on the DOS host's own draw speed, not a real-time
+             * gate, to look right. */
+            if (waitTicks != 0 && waitTicks < CUTSCENE_SPRITE_MIN_TICKS)
+                waitTicks = CUTSCENE_SPRITE_MIN_TICKS;
+#endif
             g_pCurrentCutscenePlane_00499c7c->waitTicks = waitTicks;
             g_pCurrentCutscenePlane_00499c7c->waitStart =
                 g_nInputClock_005c84a8;
+#ifdef SDL_PORT
+            SdlTracef("[plane-wait] op=0xaa plane=%p x=%d y=%d wait=%d "
+                         "clock=%d\n",
+                         (void *)g_pCurrentCutscenePlane_00499c7c,
+                         (int)g_pCurrentCutscenePlane_00499c7c->x,
+                         (int)g_pCurrentCutscenePlane_00499c7c->y,
+                         (int)waitTicks, (int)g_nInputClock_005c84a8);
+#endif
             if (objectType == 1) {
                 *scriptCursor = instruction;
                 return returnValue;
@@ -2366,6 +2412,15 @@ handle_queued_cutscene_input:
             break;
         case 0x6b:
             waitTicks = PopCutsceneScriptValue(&stack, stackStorage + 10);
+#ifdef SDL_PORT
+            SdlTracef("[sequence-wait] op=0x6b sequence=%p wait=%d "
+                         "prevWaitTicks=%d prevWaitStart=%d clock=%d\n",
+                         (void *)g_pCurrentCutsceneSequence_00499c80,
+                         (int)waitTicks,
+                         (int)g_pCurrentCutsceneSequence_00499c80->waitTicks,
+                         (int)g_pCurrentCutsceneSequence_00499c80->waitStart,
+                         (int)g_nInputClock_005c84a8);
+#endif
             if (waitTicks != 0 && g_bCutsceneSkipFrame_00499c54 == 0) {
                 while (g_nInputClock_005c84a8 <
                        g_pCurrentCutsceneSequence_00499c80->waitStart +
@@ -2373,6 +2428,11 @@ handle_queued_cutscene_input:
                     PumpWindowMessages(0);
                 }
             }
+#ifdef SDL_PORT
+            SdlTracef("[sequence-wait] op=0x6b sequence=%p done clock=%d\n",
+                         (void *)g_pCurrentCutsceneSequence_00499c80,
+                         (int)g_nInputClock_005c84a8);
+#endif
             g_pCurrentCutsceneSequence_00499c80->waitTicks = waitTicks;
             g_pCurrentCutsceneSequence_00499c80->waitStart =
                 g_nInputClock_005c84a8;

--- a/src/screens.c
+++ b/src/screens.c
@@ -2186,15 +2186,6 @@ handle_queued_cutscene_input:
             g_pCurrentCutsceneSprite_00499c78->waitTicks = waitTicks;
             g_pCurrentCutsceneSprite_00499c78->waitStart =
                 g_nInputClock_005c84a8;
-#ifdef SDL_PORT
-            SdlTracef("[sprite-wait] op=0x44 sprite=%p frame=%d x=%d y=%d "
-                         "wait=%d clock=%d\n",
-                         (void *)g_pCurrentCutsceneSprite_00499c78,
-                         (int)g_pCurrentCutsceneSprite_00499c78->currentFrame,
-                         (int)g_pCurrentCutsceneSprite_00499c78->x,
-                         (int)g_pCurrentCutsceneSprite_00499c78->y,
-                         (int)waitTicks, (int)g_nInputClock_005c84a8);
-#endif
             if (objectType == 0) {
                 *scriptCursor = instruction;
                 return returnValue;
@@ -2360,14 +2351,6 @@ handle_queued_cutscene_input:
             g_pCurrentCutscenePlane_00499c7c->waitTicks = waitTicks;
             g_pCurrentCutscenePlane_00499c7c->waitStart =
                 g_nInputClock_005c84a8;
-#ifdef SDL_PORT
-            SdlTracef("[plane-wait] op=0xaa plane=%p x=%d y=%d wait=%d "
-                         "clock=%d\n",
-                         (void *)g_pCurrentCutscenePlane_00499c7c,
-                         (int)g_pCurrentCutscenePlane_00499c7c->x,
-                         (int)g_pCurrentCutscenePlane_00499c7c->y,
-                         (int)waitTicks, (int)g_nInputClock_005c84a8);
-#endif
             if (objectType == 1) {
                 *scriptCursor = instruction;
                 return returnValue;
@@ -2397,15 +2380,6 @@ handle_queued_cutscene_input:
             break;
         case 0x6b:
             waitTicks = PopCutsceneScriptValue(&stack, stackStorage + 10);
-#ifdef SDL_PORT
-            SdlTracef("[sequence-wait] op=0x6b sequence=%p wait=%d "
-                         "prevWaitTicks=%d prevWaitStart=%d clock=%d\n",
-                         (void *)g_pCurrentCutsceneSequence_00499c80,
-                         (int)waitTicks,
-                         (int)g_pCurrentCutsceneSequence_00499c80->waitTicks,
-                         (int)g_pCurrentCutsceneSequence_00499c80->waitStart,
-                         (int)g_nInputClock_005c84a8);
-#endif
             if (waitTicks != 0 && g_bCutsceneSkipFrame_00499c54 == 0) {
                 while (g_nInputClock_005c84a8 <
                        g_pCurrentCutsceneSequence_00499c80->waitStart +
@@ -2413,11 +2387,6 @@ handle_queued_cutscene_input:
                     PumpWindowMessages(0);
                 }
             }
-#ifdef SDL_PORT
-            SdlTracef("[sequence-wait] op=0x6b sequence=%p done clock=%d\n",
-                         (void *)g_pCurrentCutsceneSequence_00499c80,
-                         (int)g_nInputClock_005c84a8);
-#endif
             g_pCurrentCutsceneSequence_00499c80->waitTicks = waitTicks;
             g_pCurrentCutsceneSequence_00499c80->waitStart =
                 g_nInputClock_005c84a8;


### PR DESCRIPTION
## Summary

- The general cutscene sprite/plane wait opcodes (`0x44`, `0xaa`) set `waitTicks` straight from script data, the same way the mouth's wait did before `CUTSCENE_MOUTH_MIN_TICKS` was introduced. A short script-authored wait relied on the DOS host's own draw speed to look right, not a real-time gate; on modern hardware the clock gate can resolve it dozens of times a second instead. Most visible as background debris (e.g. drifting past windows) racing far faster than intended.
- Adds `CUTSCENE_SPRITE_MIN_TICKS` as a sibling floor to the existing mouth floor, starting from the same already-tuned value, applied only when `waitTicks` is non-zero so objects that intentionally run unpaced every tick keep that behavior.
- Gated behind `SDL_PORT`; the MSVC reference build is unaffected (confirmed `screens.c` recompiles identically for that target).
- Also adds `INPUT_TRACE` logging around the sprite/plane/sequence wait opcodes (set and expiry), matching the existing mouth trace, since pacing bugs in this interpreter are otherwise hard to isolate from the outside.

Fixes #2 — this addressed the last remaining item from that thread (background debris speed), confirmed visually after applying the floor.

## Test plan

- [x] Rebuilt `wc2-modern.exe` (MinGW/SDL2) — compiles clean
- [x] Rebuilt the MSVC reference `WC2.EXE` — `screens.c` recompiles with the same pre-existing warnings, confirming the `SDL_PORT`-gated changes don't affect it
- [x] Captured `INPUT_TRACE=1` output before/after: wait/actual mismatch (`wanted=1 actual=5`) resolved to matching pacing (`wanted=6 actual=6-7`)
- [x] Visually confirmed in-game: debris no longer races