### PR TITLE
Let WM_CHAR-equivalent control codes reach text-entry fields

### DIFF
--- a/src/sdl/events.c
+++ b/src/sdl/events.c
@@ -411,11 +411,23 @@ static void SdlToggleFullscreen(Uint32 windowId)
 }
 
 /* WM_CHAR's contribution: the typed character, shift applied.  The game only
- * reads it for text entry, and the virtual key covers everything else. */
+ * reads it for text entry, and the virtual key covers everything else.
+ *
+ * Real WM_CHAR also fires for Backspace, Tab, Enter and Escape, with their
+ * usual C0 control codes (0x08, 0x09, 0x0d, 0x1b) -- TranslateMessage()
+ * does not restrict itself to printable output. GetNextInputEvent's type-4
+ * handling (eventmgr.c) surfaces this value, not the virtual key, as the
+ * event's final value, so zeroing those four here made WaitForAnyInputPress
+ * see 0 -- "no key yet" -- for them, and its caller would loop past the
+ * keypress waiting for a different one that never came. See issue #21
+ * (Enter never submits a pilot-name text field). */
 static int SdlKeyCharacter(const SDL_KeyboardEvent *event, int virtualKey)
 {
     int shifted;
 
+    if (virtualKey == 0x08 || virtualKey == 0x09 ||
+        virtualKey == 0x0d || virtualKey == 0x1b)
+        return virtualKey;
     if (virtualKey < ' ' || virtualKey > '~')
         return 0;
     shifted = (event->keysym.mod & (KMOD_SHIFT | KMOD_CAPS)) != 0;


### PR DESCRIPTION
## Summary

- `SdlKeyCharacter` mimics `WM_CHAR`'s contribution to a key event, but zeroed out anything outside the printable `' '..'~'` range — including Backspace (`0x08`), Tab (`0x09`), Enter (`0x0d`) and Escape (`0x1b`). Real `WM_CHAR` does fire with those exact C0 control codes for those keys; `TranslateMessage()` does not restrict itself to printable output.
- `GetNextInputEvent`'s type-4 handling (`eventmgr.c`) surfaces this character value, not the virtual key, as the event's final value. Zeroing those four keys meant `WaitForAnyInputPress` saw `0` — its "no key yet" sentinel — for them, and `WaitForQueuedInputPress`'s caller looped straight past the keypress waiting for a different one that never came.
- The pilot-name/callsign entry screen was the most visible symptom: typed letters worked (their character value survived), but Enter never submitted a field and Backspace never deleted a character, leaving a mouse click as the only way through the screen.

Fixes #21

## Root cause diagnosis

Traced with `INPUT_TRACE=1`: the raw SDL keydown for Enter was correctly detected and queued (`type=4 scan=0x1c vk=0x0d`), so the bug wasn't at the SDL event layer. Adding a trace at the point `ReadTextInput`'s modal loop reads `WaitForQueuedInputPress()` showed it firing for every letter typed but never once for Enter or Backspace — meaning the value returned from the queue for those two keys was different from what letters returned, even though both are queued identically as type-4 events. That led to `SdlKeyCharacter`, whose printable-only filter silently zeroes exactly the four control keys that matter here.

## Test plan

- [x] Rebuilt `wc2-modern.exe` (MinGW/SDL2) — compiles clean
- [x] Verified the reference `WC2.EXE` build is unaffected (this file is SDL-port-only, not compiled into that target)
- [x] Visually confirmed in-game: Enter now submits the first name/last name/callsign fields, and Backspace deletes characters, on the New Pilot screen