### PR TITLE
Stop an uninitialized poll from reading as a phantom hotspot click

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -174,7 +174,21 @@ short PollSceneHotspotInput(void *scenePacket, short offsetX,
                             short maximumSelection)
 {
     short selection;
+#ifdef SDL_PORT
+    /* GetNextInputEvent leaves state->type untouched when the queue is
+     * empty (it only ever sets x/y in that case) -- fine for its other
+     * callers, who already know an event is waiting, but this function
+     * falls back to &event below whenever FindQueuedInputEvent(1) finds
+     * no click anywhere in the queue, then calls GetNextInputEvent(&event)
+     * regardless of whether anything is actually queued. An uninitialized
+     * event.type that happens to equal 1 reads as a real click at the
+     * current cursor position, with no input at all -- the main screen
+     * and mission-select door hotspots advancing with zero input. See
+     * issue #22. */
+    InputEventState event = {0};
+#else
     InputEventState event;
+#endif
     InputEventState *inputEvent;
     short controlPressed;
     short jPressed;


### PR DESCRIPTION
## Summary

- `PollSceneHotspotInput` falls back to a local `InputEventState` when `FindQueuedInputEvent(1)` finds no click anywhere in the queue, then always calls `GetNextInputEvent` on it regardless of whether anything is actually queued.
- `GetNextInputEvent`'s empty-queue path only ever sets `state->x`/`state->y` — `state->type` is left untouched, so an uninitialized local's `->type` is whatever garbage happened to be on the stack.
- When that garbage equals `1`, the hotspot at the current cursor position reads as freshly clicked, with no input at all.
- This is undefined behavior in shared code, not a deliberate original design choice, so it isn't something binary-comp would have verified as intentional. Zero-initializes the fallback `event`, gated behind `SDL_PORT` — the MSVC reference build apparently gets a harmless value here today from its own stack layout, so it's left untouched rather than risking its assembly match.

The main "hub" screen and mission-select door hotspots advancing straight into the next cutscene/mission with zero input was the visible symptom.

Fixes #22

## Root cause diagnosis

Found by reading `PollSceneHotspotInput` (disk.c) and `GetNextInputEvent` (eventmgr.c) together: the former's fallback path is the only caller of `GetNextInputEvent` that doesn't already know an event is present, and the latter's contract silently assumes the opposite.

## Test plan

- [x] Rebuilt `wc2-modern.exe` (MinGW/SDL2) — compiles clean
- [x] Verified the reference `WC2.EXE` build compiles `disk.c` identically (same pre-existing output, no new warnings) — the change is entirely inside `#ifdef SDL_PORT`
- [x] Visually confirmed in-game: the main screen and door hotspots no longer auto-advance with zero input