### PR TITLE
Don't let a trailing auto-repeat keydown undo the yaw/pitch/roll reset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -677,6 +677,11 @@ short player_input(void)
     short vertical;
     int savedPlayerInputActive;
     HostMouseMessage *mouse;
+#ifdef SDL_PORT
+    signed char trailingKeyRelease;
+
+    trailingKeyRelease = 0;
+#endif
 
     result = 0;
     mouse = &g_stHostMouseMessage_005d10d0;
@@ -863,12 +868,38 @@ short player_input(void)
         case 6:
             result = 1;
         case 4:
+#ifdef SDL_PORT
+            trailingKeyRelease = 0;
+#endif
             g_nCockpitControlGoal_0049d7d0 = 0;
             g_cCurrentKey_00493128 = (signed char)event.status;
             process_player_input();
             break;
+#ifdef SDL_PORT
+        case 5:
+            trailingKeyRelease = 1;
+            break;
+#endif
         }
     }
+#ifdef SDL_PORT
+    /* The reset above only peeks the queue for a pending keyup before this
+     * loop runs, so a trailing auto-repeat keydown still queued behind
+     * that keyup -- ordinary at the exact moment a key is released -- gets
+     * processed afterward and calls process_player_input() one more time,
+     * incrementing yaw/pitch/roll right back up and undoing the reset that
+     * already happened. Catch that here: if the last discrete flight event
+     * this loop actually saw was a release, not a fresh press, the reset
+     * still applies no matter what ran in between. */
+    if (trailingKeyRelease != 0 &&
+        g_bPolledFlightInputQueued_005c587a == 0 &&
+        g_nCockpitControlState_0049d7ac == 0) {
+        g_nYawInput_004931aa =
+            g_nPitchInput_004931a8 =
+            g_nRollInput_004931ac =
+            g_bMouseMoveEventQueued_0049d7fc = 0;
+    }
+#endif
 
     if (g_bSecondaryMouseButtonHeld_0049d7f4 == 1)
         g_cCurrentKey_00493128 = 0xf;


### PR DESCRIPTION
## Summary

- `player_input`'s reset-on-keyup check peeks the input queue for a pending keyup *before* the event-drain loop runs that frame.
- If a trailing auto-repeat keydown for the same key is still queued immediately behind the keyup — an ordinary consequence of OS repeat timing at the exact moment of release — the drain loop processes that keydown afterward and calls `process_player_input()` one more time, incrementing yaw/pitch/roll right back up and silently undoing the reset that already happened in the same frame.
- Result: the ship keeps rotating in the last-commanded direction indefinitely after releasing an arrow/numpad key, even with no input held.

Fixes #28

## Fix

Track whether the last discrete flight event the drain loop actually saw was a release, not a fresh press, and apply the same reset after the loop if so. This is a **supplement** to the existing pre-loop check, not a replacement — both use the same gating conditions (`g_bPolledFlightInputQueued_005c587a` and `g_nCockpitControlState_0049d7ac`), so this only catches the timing gap the existing check misses.

Gated behind `SDL_PORT`; the MSVC reference build is untouched. This bug is in shared code, not `SDL_PORT`-gated, so it's very likely present in the original Kilrathi Saga executable too — reconstructed faithfully there rather than "fixed" out of byte-comparable behavior.

Only affects **keyboard** flight input (the discrete keydown/keyup event path). Mouse-driven flight (`case 3`) and joystick/gamepad polled input (`case 7`) are separate mechanisms and untouched — the fix's own gate explicitly requires `g_bPolledFlightInputQueued_005c587a == 0` to fire, deferring entirely to the joystick path when one is active.

## Root cause diagnosis

Traced with `INPUT_TRACE=1` and targeted tracing added during investigation (removed before this PR): confirmed the keyup event was cleanly received at the SDL layer, confirmed the reset check's two gating conditions were both satisfied (should have fired), and confirmed yaw was reset to 0 that frame — but the *next* frame's value had already climbed back to 1, revealing the trailing-keydown race rather than a gating or queue-integrity issue (two earlier hypotheses along those lines were tested and ruled out).

## Test plan

- [x] Rebuilt `wc2-modern.exe` (MinGW/SDL2) — compiles clean
- [x] Verified the reference `WC2.EXE` build compiles `main.c` identically (same pre-existing unrelated warning, no new ones) — the change is entirely inside `#ifdef SDL_PORT`
- [x] Visually confirmed in-game: tapping and releasing an arrow key no longer leaves the ship rotating