### PR TITLE
Show and center the target VDU shield strength indicator

### DIFF
--- a/src/logic.c
+++ b/src/logic.c
@@ -2903,6 +2903,24 @@ void InitializeCockpitResources(short shipType)
     g_nHudMessageBackgroundDepth_0049b294 = 0;
     LoadShapeSet(g_aCockpitCommonShapeResources_0049c820, 0,
                  g_szCockpitResourceFilename_005d1030);
+#ifdef SDL_PORT
+    /* See issue #30: LoadShapeSet aborts the whole list on the first
+     * missing resource, and g_pCockpitWeaponShape_005d2b54 (the ship's
+     * cockpit weapon-display shape, section 12 of the ship-specific
+     * pcshipNN.v file) is legitimately absent for ship types that have
+     * no cockpit weapon display -- code elsewhere already null-checks it
+     * before use. But that abort also skips every later entry in the
+     * same list, including g_pCockpitIndicatorShape_005d2c48 (the target
+     * VDU's shield-strength indicator sprite, cockpit.vga section 4),
+     * which has nothing to do with the ship-specific failure and is
+     * always present. The result: any ship without a cockpit weapon
+     * display never shows shield strength on a locked target, even at
+     * full shields. Load it directly if the set above left it null. */
+    if (g_pCockpitIndicatorShape_005d2c48 == 0) {
+        g_pCockpitIndicatorShape_005d2c48 =
+            FetchDiskPacketRetrying("cockpit.vga", 4, 0x40);
+    }
+#endif
     g_pScannerMarkerBackground_005d1c2c = AllocateTaggedMemory(
         (unsigned int)MeasureShapeFrameStorage(
             g_pCockpitHudShape_005d21f4, 2),

--- a/src/music.c
+++ b/src/music.c
@@ -474,7 +474,21 @@ void show_target_disp(void)
     }
     if (g_asShipIdentified_00496078[target] == 0)
         return;
+#ifdef SDL_PORT
+    /* See issue #30: retail anchors the target silhouette (ship outline,
+     * armor overlay, and shield indicator all draw from this same x) 1
+     * pixel right of dead centre in the 72px-wide right VDU viewport
+     * (0x25 == 37, but half of a 72px-wide viewport is 0x24 == 36).
+     * That single native pixel is invisible at DOS's native resolution,
+     * but the port upscales the cockpit, which turns it into a visible
+     * rightward bias -- the shield bracket's right arc clips against the
+     * panel edge while its left arc has a matching gap. Center it
+     * properly; ship, armor, and shield all still share this one x, so
+     * they stay aligned with each other. */
+    x = (short)(g_stRightVduViewport_005d2b20.left + 0x24);
+#else
     x = (short)(g_stRightVduViewport_005d2b20.left + 0x25);
+#endif
     y = (short)(g_stRightVduViewport_005d2b20.top + 0x26);
     frame = (short)(g_aasShipShield_00495518[target][1] * 6 /
                     typeData->shieldAft);


### PR DESCRIPTION
## Summary

Fixes #30.

The target VDU's shield-strength indicator (the bracket drawn around a
locked target's silhouette showing fore/aft shield strength) never
rendered at all for any player ship without a cockpit weapon-display
shape.

## Root cause

`LoadShapeSet` aborts its whole resource list on the first missing
entry. `g_pCockpitWeaponShape_005d2b54` (the ship's own cockpit
weapon-display shape) is legitimately absent for ship types that don't
have a cockpit weapon display -- code elsewhere already null-checks it
before use -- but it sits right before the shield indicator sprite
(`g_pCockpitIndicatorShape_005d2c48`, loaded from the always-present
shared `cockpit.vga`) in the same resource list. So the weapon shape's
expected absence silently skipped loading the shield indicator too,
even though the indicator has nothing to do with the ship-specific
failure.

Once that was fixed and the indicator started rendering, it (and the
ship silhouette/armor overlay sharing the same draw anchor) turned out
to sit 1 native pixel off dead-centre in the 72px-wide VDU viewport
(`0x25` == 37, half of 72 is `0x24` == 36). That's invisible at DOS's
native resolution, but becomes a visible rightward bias once the port
upscales the cockpit -- the shield bracket's right arc clipped against
the panel edge while its left arc had a matching gap.

## Fix

- In the SDL2 port, load the shield indicator sprite directly if
  `LoadShapeSet` left it null.
- Center the shared draw anchor so the ship outline, armor overlay, and
  shield indicator all stay aligned with each other and centered in the
  viewport.

Both gated behind `SDL_PORT`; the MSVC reference build (`WC2.EXE`) is
byte-identical, verified by a clean rebuild with no new warnings.

## Test plan

- [x] Rebuilt `wc2-modern.exe` and confirmed the shield indicator now
      renders on a locked target, correctly reflecting shield strength
- [x] Confirmed the indicator is centered and no longer clips against
      the panel edge or overlaps the ship silhouette
- [x] Rebuilt the MSVC reference target (`logic.obj`, `music.obj`) with
      no new warnings, confirming no behavior change outside `SDL_PORT`