### PR TITLE
Fix comm portrait/VDU getting stuck after a wingman or enemy message

### DIFF
--- a/src/cockpt.c
+++ b/src/cockpt.c
@@ -965,7 +965,20 @@ void clear_message_time(void)
 /* Function start: 0x43952E */
 short message_showing(void)
 {
+#ifdef SDL_PORT
+    /* See issue #27: -1 is the "waiting on speech playback" sentinel (see
+     * set_message_time), and check_message() below already has a dedicated
+     * branch for g_nHudMessageTime_005d1c32 == -1 that detects speech
+     * completion and calls EndCommMenu(). But this strict "0 <" test made
+     * that branch unreachable -- -1 read as "not showing", so check_message()
+     * never even looked at hudtime while it was in the wait state, and the
+     * comm portrait/VDU stayed on screen forever once the speech line
+     * finished. Treat -1 as showing (waiting), matching what every other
+     * caller here already assumes when a HUD message or comm portrait is up. */
+    return g_nHudMessageTime_005d1c32 != 0;
+#else
     return 0 < g_nHudMessageTime_005d1c32;
+#endif
 }
 
 /* Function start: 0x439559 */

--- a/src/screen.c
+++ b/src/screen.c
@@ -1405,6 +1405,19 @@ void real_vid_transmit(short obj, short message)
     if (g_bSpeechCacheEnabled_005c8de8 != 0 && packetSize > 0 &&
         packetSize < g_wSpeechCacheCodeBytes_0048e0e0) {
         DismissHudMessageIfShowing();
+#ifdef SDL_PORT
+        /* See issue #27: DismissHudMessageIfShowing() only arms the "-1"
+         * wait-for-speech sentinel (via set_message_time) when a HUD
+         * message was already showing. vid_equiv() only starts a new
+         * comm transmission once message_showing() is already false, so
+         * on the normal path the sentinel never gets armed here:
+         * check_message() then never sees g_nHudMessageTime_005d1c32 ==
+         * -1 and so never notices g_bSpeechPlaybackComplete_004a266c go
+         * true, leaving the comm portrait/VDU stuck once the speech line
+         * finishes playing. Arm the sentinel unconditionally so playback
+         * completion always gets observed. */
+        set_message_time(-1);
+#endif
         LoadAndPlaySpeechPacket(packetName, message);
         g_bCommSpeechPlaying_0049b7a0 = 1;
         return;


### PR DESCRIPTION
## Summary
Fixes #27.

The comm portrait/VDU could get stuck on screen indefinitely after a
wingman or enemy speech-based transmission finished playing.

Root cause, two layers deep:

1. `vid_equiv()` only starts a new comm transmission once
   `message_showing() == 0`. `real_vid_transmit()`'s speech-cache
   branch relies on `DismissHudMessageIfShowing()` to arm the "-1,
   waiting on speech" sentinel in `g_nHudMessageTime_005d1c32` -- but
   that function only does so if a message is *already* showing,
   which by the caller's own precondition is never true. The sentinel
   was effectively never armed.
2. Separately, `message_showing()` treated `-1` as "not showing"
   (`0 < hudtime`), even though `check_message()` has a dedicated
   branch for `hudtime == -1` that detects speech completion
   (`g_bSpeechPlaybackComplete_004a266c`) and ends the comm session
   via `EndCommMenu()`. That branch was unreachable behind
   `message_showing()`'s outer gate, so even once (1) is fixed, the
   completion was never observed.

Both changes are gated behind `#ifdef SDL_PORT`; the DOS reference
build (`WC2.EXE`, MSVC 4.1) is untouched.

Diagnosed and confirmed fixed via `INPUT_TRACE=1` runtime tracing.

## Test plan
- [x] Reproduced the freeze reliably with `INPUT_TRACE=1` before the fix
- [x] Confirmed via trace: `hudtime` now transitions to `-1` (armed) and
      back to `0` (comm closed) instead of sticking forever
- [x] Confirmed in-game the comm portrait/VDU closes normally after a
      wingman/enemy message
- [x] Both `WC2.EXE` and `wc2-modern.exe` build clean