### PR TITLE
Fix radio command hotkeys (Alt+B/F/A/H/D/T) not working in the SDL port

### DIFF
--- a/src/hudmsg.c
+++ b/src/hudmsg.c
@@ -178,6 +178,10 @@ short HandleSpaceFlightControls(void)
         g_aeShipObjective_00495f08[g_nYourWingman_0049346c] ==
             OBJECTIVE_HOLD_FORMATION &&
         any_enemy(0, 14000) != 0) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+B implemented: break and attack "
+                  "(wingman=%d)\n", (int)g_nYourWingman_0049346c);
+#endif
         IssueQuickCommCommand(g_nYourWingman_0049346c, 4);
         g_nLastAltCommandScanCode_005d1274 = 0x30;
     }
@@ -189,6 +193,10 @@ short HandleSpaceFlightControls(void)
     if (g_bAltFHotkey_005d127c != 0 &&
         g_nLastAltCommandScanCode_005d1274 != 0x21 &&
         g_nYourWingman_0049346c != -1) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+F implemented: keep formation / form "
+                  "on wing (wingman=%d)\n", (int)g_nYourWingman_0049346c);
+#endif
         IssueQuickCommCommand(g_nYourWingman_0049346c, 6);
         g_nLastAltCommandScanCode_005d1274 = 0x21;
     }
@@ -196,6 +204,11 @@ short HandleSpaceFlightControls(void)
         g_nLastAltCommandScanCode_005d1274 != 0x1e &&
         g_nYourWingman_0049346c != -1 &&
         g_acShipTarget_00495f20[0] != -1) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+A implemented: attack my target "
+                  "(wingman=%d target=%d)\n", (int)g_nYourWingman_0049346c,
+                  (int)g_acShipTarget_00495f20[0]);
+#endif
         IssueQuickCommCommand(g_nYourWingman_0049346c, 1);
         g_nLastAltCommandScanCode_005d1274 = 0x1e;
     }
@@ -203,12 +216,20 @@ short HandleSpaceFlightControls(void)
         g_nLastAltCommandScanCode_005d1274 != 0x23 &&
         g_nYourWingman_0049346c != -1 &&
         any_enemy(0, 14000) != 0) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+H implemented: help me out here "
+                  "(wingman=%d)\n", (int)g_nYourWingman_0049346c);
+#endif
         IssueQuickCommCommand(g_nYourWingman_0049346c, 2);
         g_nLastAltCommandScanCode_005d1274 = 0x23;
     }
     if (g_bAltDHotkey_005d1280 != 0 &&
         g_nLastAltCommandScanCode_005d1274 != 0x20 &&
         g_nYourWingman_0049346c != -1) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+D implemented: damage report "
+                  "(wingman=%d)\n", (int)g_nYourWingman_0049346c);
+#endif
         IssueQuickCommCommand(g_nYourWingman_0049346c, 13);
         g_nLastAltCommandScanCode_005d1274 = 0x20;
     }
@@ -217,6 +238,10 @@ short HandleSpaceFlightControls(void)
         g_acShipTarget_00495f20[0] != -1 &&
         g_asShipSide_004955d0[g_acShipTarget_00495f20[0]] ==
             SIDE_KILRATHI) {
+#ifdef SDL_PORT
+        SdlTracef("[althotkey] Alt+T implemented: taunt (target=%d)\n",
+                  (int)g_acShipTarget_00495f20[0]);
+#endif
         IssueQuickCommCommand(
             g_acShipTarget_00495f20[0],
             (short)((unsigned short)RandomInRange(0, 2) +

--- a/src/sdl/events.c
+++ b/src/sdl/events.c
@@ -440,6 +440,41 @@ void SdlTraceInputEvent(const char *what, int type, int scanCode,
     fflush(stderr);
 }
 
+/* See issue #7: the retail radio-command hotkeys (Alt+B/F/A/H/D/T -- the
+ * wingman "quick comm" shortcuts, see IssueQuickCommCommand calls in
+ * hudmsg.c) are recognised in MainWindowProc's WM_SYSKEYDOWN/WM_SYSKEYUP
+ * handling in winmain.c, which is #ifndef SDL_PORT and so does not exist in
+ * this build at all: none of g_bAlt{A,B,F,H,D,T}Hotkey_* ever gets set here,
+ * making the shortcuts silent no-ops rather than merely unreliable.
+ *
+ * MainWindowProc's WM_SYSKEYUP handler was also the direct cause of the
+ * "erratic wingmate AI behaviour" half of #7: it clears every one of these
+ * flags together on *any* key release while Alt is held, not just the
+ * release of the key that set them -- so holding Alt and tapping two
+ * letters in a row could wipe a flag that had just been set for the second
+ * letter, or (since Break-and-Attack and Keep-Formation are opposite
+ * objectives) let two conflicting quick-comm commands fire back to back.
+ *
+ * Each SDL key event already names its own key, so track and clear each
+ * flag independently off its own SDL_KEYDOWN/SDL_KEYUP pair instead of one
+ * shared "any key up" reset. */
+static void SdlUpdateAltHotkey(const SDL_KeyboardEvent *event, int pressed,
+                               SDL_Scancode scancode, int *flag,
+                               const char *label)
+{
+    if (event->keysym.scancode != scancode)
+        return;
+    if (!pressed) {
+        *flag = 0;
+        return;
+    }
+    if ((event->keysym.mod & KMOD_ALT) == 0)
+        return;
+    if (*flag == 0 && event->repeat == 0)
+        SdlTracef("[althotkey] Alt+%s intercepted\n", label);
+    *flag = 1;
+}
+
 static int SdlHandleKeyboardEvent(const SDL_KeyboardEvent *event)
 {
     int pressed;
@@ -463,6 +498,18 @@ static int SdlHandleKeyboardEvent(const SDL_KeyboardEvent *event)
         event->keysym.scancode == SDL_SCANCODE_LALT ||
         event->keysym.scancode == SDL_SCANCODE_RALT)
         g_dwSystemKey_005d10a4 = pressed ? (unsigned int)virtualKey : 0;
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_B,
+                      &g_bAltBHotkey_005d1290, "B");
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_F,
+                      &g_bAltFHotkey_005d127c, "F");
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_A,
+                      &g_bAltAHotkey_005d1294, "A");
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_H,
+                      &g_bAltHHotkey_005d128c, "H");
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_D,
+                      &g_bAltDHotkey_005d1280, "D");
+    SdlUpdateAltHotkey(event, pressed, SDL_SCANCODE_T,
+                      &g_bAltTHotkey_005d1298, "T");
     if (event->keysym.scancode == SDL_SCANCODE_F1)
         g_bF1KeyDown_0049c240 = pressed && event->repeat == 0;
     if (pressed && scanCode == 1)


### PR DESCRIPTION
## Summary
Fixes #7.

In the SDL port, the Alt+letter radio-command shortcuts (Break and
Attack, Keep Formation/Form on Wing, Attack My Target, Help Me Out
Here, Damage Report, Taunt) didn't work at all -- not merely
unreliable, as reported against the Kilrathi Saga win32 build, but a
complete no-op every time.

Root cause: these shortcuts are recognised in `MainWindowProc`'s
`WM_SYSKEYDOWN`/`WM_SYSKEYUP` handling (`winmain.c`), which sets/clears
`g_bAlt{A,B,F,H,D,T}Hotkey_*`. That function is `#ifndef SDL_PORT` and
doesn't exist in this build -- the SDL port never creates a real Win32
window to route those messages to, and nothing in `src/sdl/events.c`
touched those flags either.

Fix: track and set/clear each flag directly off its own
`SDL_KEYDOWN`/`SDL_KEYUP` pair in the SDL event handler
(`SdlUpdateAltHotkey` in `src/sdl/events.c`). This also fixes the
"erratic wingmate AI behaviour" half of #7 as a side effect:
`MainWindowProc`'s `WM_SYSKEYUP` handler cleared all six flags
together on *any* key release while Alt was held, not just the
release of the key that set them, so holding Alt and tapping two
letters in a row could wipe a flag that had just been set for the
second letter, or fire two conflicting quick-comm commands back to
back. Each SDL key event already names its own key, so there's no
equivalent cross-key interference in the new code.

Also adds `INPUT_TRACE=1` logging (`[althotkey] Alt+X intercepted` /
`implemented`) at both the input layer and the point each hotkey
actually issues its quick-comm command, to make future reports easier
to diagnose.

Both changes are gated behind `#ifdef SDL_PORT` / live only in
`src/sdl/*`; the DOS reference build (`WC2.EXE`, MSVC 4.1) is
untouched.

## Test plan
- [x] Confirmed via `INPUT_TRACE=1` trace: Alt+B and Alt+A both show
      `intercepted` followed by `implemented` and the command fires
- [x] Confirmed in-game: wingman responds correctly to Break and
      Attack / Attack My Target shortcuts
- [x] Both `WC2.EXE` and `wc2-modern.exe` build clean