### PR TITLE
Fix crash reloading a savegame from the campaign chalkboard menu

### DIFF
--- a/src/hudmsg.c
+++ b/src/hudmsg.c
@@ -1716,6 +1716,26 @@ short calculate_damage_level(void)
 /* Function start: 0x419A40 */
 void CopyHugeMemoryOverlapSafe(void *destination, void *source, int count)
 {
+#ifdef SDL_PORT
+    /* See issue #37 (crash reloading a savegame): DosFarPtrToNear/
+     * DosNearPtrToFar round-trip a pointer through "unsigned int" -- exactly
+     * correct on the 32-bit reference build (a dword IS a pointer there,
+     * see the DwordPtr comment in game.h), but on this 64-bit build it
+     * silently truncates the upper 32 bits. The branch below reconstructs
+     * both pointers through that round-trip unconditionally, and which
+     * branch runs depends on comparing the two pointers' truncated low 32
+     * bits -- so whether this corrupts the pointers effectively comes down
+     * to heap-address luck, reproducing more often the more the heap has
+     * churned (e.g. reopening the save/load menu a second time).
+     *
+     * The 0xffff-sized chunking in both branches below exists only to stay
+     * within a DOS segment's 64KB limit; that does not apply on a flat
+     * 64-bit address space, so a plain memmove is exactly equivalent and
+     * correct regardless of overlap -- which is exactly what this
+     * hand-rolled routine's name promises. */
+    if (count != 0)
+        memmove(destination, source, (size_t)count);
+#else
     if (count != 0) {
         if (DosFarPtrToNear(source) < DosFarPtrToNear(destination)) {
             destination = DosNearPtrToFar(
@@ -1745,6 +1765,7 @@ void CopyHugeMemoryOverlapSafe(void *destination, void *source, int count)
             DosMemcpy(destination, source, (unsigned int)count);
         }
     }
+#endif
 }
 
 #pragma function(memset)


### PR DESCRIPTION
## Summary
Fixes #37.

Loading a savegame, then loading it (or any other) again from the
campaign chalkboard's "Select a game to load" menu reliably crashed
with an access violation inside `ucrtbase.dll`, with no diagnostic
output.

Root cause: `CopyHugeMemoryOverlapSafe()` (`hudmsg.c`) round-trips its
pointers through `DosFarPtrToNear`/`DosNearPtrToFar` (`strdos.c`):

```c
unsigned int DosFarPtrToNear(void *v) { return (unsigned int)v; }
void *DosNearPtrToFar(unsigned int v) { return (void *)v; }
```

`unsigned int` is 32 bits -- a lossless no-op on the 32-bit reference
build (a dword *is* a pointer there, see the `DwordPtr` comment in
`game.h`), but on this 64-bit build it silently truncates the upper 32
bits of any pointer passed through it.

I confirmed this precisely against a live crash: Windows saved a
minidump on crash (`%LOCALAPPDATA%\CrashDumps`), which I loaded with
the Debugging Tools for Windows and cross-referenced against the built
binary's own symbols. A trace I added logged the real 64-bit pointer
going into the copy (`dst=000001F389138110`); the actual faulting
register at the crash (`rdi=0000000089138110`) had identical low 32
bits with the upper half zeroed -- the exact signature of this
truncation.

Which branch of `CopyHugeMemoryOverlapSafe` runs depends on comparing
the two pointers' truncated low 32 bits against each other, so whether
this corrupts a pointer comes down to heap-address luck -- explaining
why it reproduced far more reliably the *second* time the save/load
menu was opened (more heap churn shifts the odds toward the bad
branch), rather than being a hard, deterministic every-time crash.

## Fix
The `0xffff`-sized chunking this function does only exists to stay
within a DOS segment's 64KB addressing limit, which doesn't apply on a
flat 64-bit address space. Under `SDL_PORT`, skip all of that and use
`memmove()` directly, which is already correctly overlap-safe --
exactly what this hand-rolled routine's name promises. Gated behind
`#ifdef SDL_PORT`; the DOS reference build (`WC2.EXE`, MSVC 4.1) is
untouched and byte-identical.

## Test plan
- [x] Reproduced the crash reliably, captured and analyzed the actual
      Windows crash dump with a debugger rather than guessing
- [x] Confirmed via trace + register comparison: the destination
      pointer was truncated to its low 32 bits at the crash site
- [x] Confirmed in-game: loading a savegame a second time from the
      chalkboard menu no longer crashes
- [x] Both `WC2.EXE` and `wc2-modern.exe` build clean