### PR TITLE
Add --ega command-line flag for an authentic EGA dither filter

### DIFF
--- a/src/sdl/launcher.c
+++ b/src/sdl/launcher.c
@@ -119,6 +119,8 @@ static int SdlParsePortArguments(int *argumentCount, char **arguments,
             launcherOptions->joystickAxes = SdlFindLauncherChoice(
                 argument + 16, g_apszSdlLauncherJoystickAxes,
                 SDL_arraysize(g_apszSdlLauncherJoystickAxes));
+        } else if (strcmp(argument, "--ega") == 0) {
+            SdlEnableEgaDither();
         } else {
             legacyCommand = argument[0] == '-' ? argument[1] : argument[0];
             if (legacyCommand == 'f')
@@ -249,6 +251,16 @@ static void SdlApplyLegacyArguments(int argumentCount, char **arguments)
 static int SdlRunRuntimeChecks(void)
 {
     short object;
+    unsigned char framePalette[256 * 4];
+    unsigned char framePixels[SDL_FRAME_WIDTH * SDL_FRAME_HEIGHT];
+
+    /* Exercise the full presentation contract, including the GL backend's
+     * copy of all 256 palette entries -- catches an EGA-filter buffer size
+     * mismatch the same way wc1-re's own version of this check does. */
+    memset(framePixels, 0, sizeof(framePixels));
+    memset(framePalette, 0, sizeof(framePalette));
+    if (!SdlPresentIndexedFrame(framePixels, framePalette))
+        return 1;
 
     g_aShipWeapons_004956b0[1][0] = 2;
     remove_weapon(1, 0);

--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -8,6 +8,80 @@ static SDL_Texture *g_pSdlFrameTexture;
 static Uint32 g_adwSdlFramePixels[
     SDL_FRAME_WIDTH * SDL_FRAME_HEIGHT];
 
+/* EGA compatibility filter (--ega). WC2's own reconstructed engine is
+ * hardcoded to MCGA/VGA mode 0x13 (g_szRasterDriverName_004902ac is always
+ * "MCGA.DLL", and several LogDisplayMode("not MCGA")-style fatal checks
+ * abort on anything else) -- unlike WC1, no EGA path exists anywhere in
+ * what this project reconstructs. But WC2's *original* 1991 floppy
+ * release (predating the VGA-only "Kilrathi Saga" CD-ROM release this
+ * project is based on) did ship a real EGA installer, confirmed directly:
+ * its own INSTALL.EXE (from an original install disk) has a genuine
+ * VGA->EGA conversion routine, structurally identical to WC1's (traced
+ * live under a paused DOSBox Staging debugger session, same technique as
+ * WC1's --ega filter) -- a 256-entry table where each byte packs two 4-bit
+ * EGA color indices (high nibble / low nibble), with the per-pixel loop
+ * alternating (`xor bx, 100h`) between the two on every pixel, checkerboard
+ * -seeded per scanline. The table itself was read directly out of live
+ * DOSBox memory mid-conversion. Unlike WC1's table, WC2's own reserves its
+ * first 16 VGA palette indices as an exact identity mapping onto the EGA
+ * palette (byte i == (i << 4) | i for i in 0..15) -- no dithering needed
+ * for those indices, only for the rest of the 256-color palette.
+ * The per-scanline checkerboard seed `(x+y)&1` reproduces the confirmed
+ * "toggle every pixel" mechanism; the installer's own precise seed
+ * computation was not independently re-derived bit-for-bit, so this is the
+ * standard ordered-dither seed, not a byte-exact trace of that one
+ * instruction sequence. */
+static int g_bEgaDitherEnabled;
+static unsigned char g_abEgaDitherPixels[
+    SDL_FRAME_WIDTH * SDL_FRAME_HEIGHT];
+/* Both host renderers accept a complete 256-entry [B,G,R,pad] palette even
+ * though converted pixels only use the first 16 entries. */
+static unsigned char g_abEgaDitherPalette[256 * 4];
+
+static const unsigned char g_abEgaDitherTable[256] = {
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    0x88, 0xff, 0xf7, 0x77, 0x77, 0x77, 0x77, 0x77, 0xc7, 0x66, 0x68, 0x88, 0x88, 0x88, 0x00, 0x00,
+    0xff, 0xf7, 0x77, 0x79, 0x99, 0x99, 0x91, 0x11, 0x11, 0x11, 0x11, 0x10, 0x10, 0x11, 0x00, 0x00,
+    0xff, 0x77, 0x77, 0x77, 0x77, 0x88, 0x88, 0x88, 0x98, 0x98, 0x91, 0x10, 0x10, 0x00, 0x00, 0x00,
+    0xff, 0xee, 0xee, 0xee, 0xee, 0xee, 0xc6, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x00, 0x00,
+    0xff, 0xf7, 0x77, 0xcc, 0xc7, 0xcc, 0xcc, 0x44, 0xee, 0xea, 0xaa, 0xaa, 0xaa, 0x22, 0x22, 0x00,
+    0xff, 0xf7, 0x77, 0x77, 0x7e, 0x7e, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x68, 0x60, 0x00, 0x00,
+    0xff, 0xf7, 0x77, 0x77, 0xc7, 0xc7, 0x66, 0x66, 0x66, 0x64, 0x64, 0x44, 0x00, 0x00, 0x00, 0x00,
+    0xff, 0xff, 0xff, 0xfc, 0xcc, 0xcc, 0xcc, 0xcc, 0x66, 0x66, 0x64, 0x48, 0x40, 0x00, 0x00, 0x00,
+    0xff, 0xff, 0xfb, 0xb7, 0xb7, 0x33, 0x33, 0x33, 0xbb, 0x33, 0x99, 0x88, 0x11, 0x00, 0x00, 0x00,
+    0xff, 0xff, 0xf7, 0x77, 0x77, 0x77, 0x77, 0x77, 0x88, 0x88, 0x37, 0x88, 0x88, 0x77, 0x88, 0x00,
+    0xff, 0xfc, 0xfc, 0xcc, 0xc5, 0x54, 0x54, 0x54, 0x55, 0x54, 0x54, 0x58, 0x50, 0x00, 0x00, 0x00,
+    0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
+    0xff, 0xf7, 0x77, 0x77, 0x77, 0x77, 0x7f, 0x77, 0xa7, 0xa7, 0xaa, 0x82, 0x72, 0x28, 0x22, 0x00,
+    0xff, 0x77, 0x77, 0x76, 0x66, 0x88, 0x88, 0x00, 0x66, 0x66, 0x66, 0x64, 0x44, 0x48, 0x40, 0xdd,
+    0xee, 0xe7, 0x77, 0x72, 0x22, 0x28, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xdd,
+};
+
+/* Standard IBM EGA/VGA 16-color hardware palette, R/G/B 0-255. */
+static const unsigned char g_abEgaHardwarePaletteRgb[16][3] = {
+    {0x00, 0x00, 0x00}, {0x00, 0x00, 0xaa}, {0x00, 0xaa, 0x00}, {0x00, 0xaa, 0xaa},
+    {0xaa, 0x00, 0x00}, {0xaa, 0x00, 0xaa}, {0xaa, 0x55, 0x00}, {0xaa, 0xaa, 0xaa},
+    {0x55, 0x55, 0x55}, {0x55, 0x55, 0xff}, {0x55, 0xff, 0x55}, {0x55, 0xff, 0xff},
+    {0xff, 0x55, 0x55}, {0xff, 0x55, 0xff}, {0xff, 0xff, 0x55}, {0xff, 0xff, 0xff},
+};
+
+void SdlEnableEgaDither(void)
+{
+    int index;
+
+    g_bEgaDitherEnabled = 1;
+    for (index = 0; index < 16; index++) {
+        /* Same [B,G,R,pad] layout SdlPresentIndexedFrame reads below. */
+        g_abEgaDitherPalette[index * 4 + 0] =
+            g_abEgaHardwarePaletteRgb[index][2];
+        g_abEgaDitherPalette[index * 4 + 1] =
+            g_abEgaHardwarePaletteRgb[index][1];
+        g_abEgaDitherPalette[index * 4 + 2] =
+            g_abEgaHardwarePaletteRgb[index][0];
+        g_abEgaDitherPalette[index * 4 + 3] = 0;
+    }
+}
+
 int SdlInitializeVideo(SDL_Window *window)
 {
     SdlShutdownVideo();
@@ -72,12 +146,29 @@ int SdlPresentIndexedFrame(const unsigned char *pixels,
     SDL_Rect dest;
     int pixel;
     int result;
+    int restoreMouseCursor;
+
+    restoreMouseCursor =
+        g_bInputCursorBackgroundCaptured_005c80c4 != 0 &&
+        g_stScreenViewport_005d21a0.pixels == pixels;
+
+    if (g_bEgaDitherEnabled && pixels != 0) {
+        for (pixel = 0; pixel < SDL_FRAME_WIDTH * SDL_FRAME_HEIGHT;
+             pixel++) {
+            int x = pixel % SDL_FRAME_WIDTH;
+            int y = pixel / SDL_FRAME_WIDTH;
+            unsigned char packed = g_abEgaDitherTable[pixels[pixel]];
+
+            g_abEgaDitherPixels[pixel] =
+                ((x + y) & 1) ? (packed >> 4) : (packed & 0x0f);
+        }
+        pixels = g_abEgaDitherPixels;
+        palette = g_abEgaDitherPalette;
+    }
 
     if (SdlUsingGlRenderer()) {
         result = SdlGlRendererPresent(pixels, palette);
-        if (result != 0 &&
-            g_bInputCursorBackgroundCaptured_005c80c4 != 0 &&
-            g_stScreenViewport_005d21a0.pixels == pixels)
+        if (result != 0 && restoreMouseCursor)
             RestoreMouseCursorBackground();
         return result;
     }
@@ -107,8 +198,7 @@ int SdlPresentIndexedFrame(const unsigned char *pixels,
     if (SDL_RenderCopy(g_pSdlRenderer, g_pSdlFrameTexture, 0, &dest) != 0)
         return 0;
     SDL_RenderPresent(g_pSdlRenderer);
-    if (g_bInputCursorBackgroundCaptured_005c80c4 != 0 &&
-        g_stScreenViewport_005d21a0.pixels == pixels)
+    if (restoreMouseCursor)
         RestoreMouseCursorBackground();
     return 1;
 }
@@ -163,7 +253,10 @@ int SdlRecordSpaceSprite(
     unsigned char *shape, short frame, short angle, short scale,
     short flip)
 {
-    if (!SdlUsingGlRenderer())
+    /* The enhanced/GL layer records sprites using raw VGA palette indices;
+     * once EGA dithering has converted the composed frame those indices no
+     * longer mean anything, so keep the composition point instead. */
+    if (!SdlUsingGlRenderer() || g_bEgaDitherEnabled)
         return 0;
     return SdlGlRendererRecordSpaceSprite(
         viewport, x, y, shape, frame, angle, scale, flip);

--- a/src/sdl/video_internal.h
+++ b/src/sdl/video_internal.h
@@ -15,6 +15,7 @@ typedef enum SdlVideoBackend {
 
 void SdlSetVideoBackend(SdlVideoBackend backend);
 int SdlUsingGlRenderer(void);
+void SdlEnableEgaDither(void);
 int SdlConfigureVideoWindow(Uint32 *windowFlags);
 void SdlCalculateOutputViewport(int width, int height, int *left,
                                    int *bottom, int *viewportWidth,


### PR DESCRIPTION
## Summary
Fixes #39.

Adds a `--ega` command-line flag that renders the game through the
*real* VGA->EGA conversion algorithm WC2's original 1991 DOS installer
used on real EGA installs -- the same feature added to wc1-re
(schlangz/wc1-re#11), ported over per #39.

As with WC1: this reconstruction (the VGA-only "Kilrathi Saga" CD-ROM
release) has no EGA code path at all -- `g_szRasterDriverName_
004902ac` is hardcoded to `"MCGA.DLL"`, and several
`LogDisplayMode("not MCGA")` fatal checks abort on anything else. But
WC2's *original* 1991 floppy release shipped a real EGA installer.
I confirmed and extracted the actual algorithm and table by
live-tracing that installer's own `INSTALL.EXE` (from an original
install disk) under a paused DOSBox Staging debugger session, the
same technique used for WC1.

The two installers turn out to share the same codebase almost
exactly -- WC2's conversion routines (`sub_17B80`/`sub_17D36`) are
byte-for-byte the same size as WC1's (`sub_175FA`/`sub_177B0`), and
implement the identical algorithm: a 256-entry table where each byte
packs two 4-bit EGA color indices (high nibble / low nibble), with
the per-pixel loop alternating (`xor bx, 100h`) between the two on
every pixel, checkerboard-seeded per scanline. A genuine 2-color
ordered dither using a hand-authored table, not per-channel RGB math.

The table itself is naturally different from WC1's (different game,
different palette) -- pulled directly from live DOSBox memory
mid-conversion, and independently re-confirmed byte-identical across
three separate files being converted in the same session, confirming
it's a single table built once and reused for the whole conversion,
not per-image data. One nice detail: WC2's table reserves its first
16 VGA palette indices as an exact identity mapping onto the EGA
palette (byte `i == (i << 4) | i` for `i` in 0-15) -- WC1's didn't do
this.

Applied in `SdlPresentIndexedFrame()`, the single point both the
plain SDL renderer and the GL/enhanced renderer path already funnel
through, with `SdlRecordSpaceSprite()` guarded against combining
`--ega` with `--enhanced` (the GL layer's own sprite recording uses
raw VGA indices, incompatible with a fixed 16-color palette). All new
SDL-port-only code (`src/sdl/video.c`, `video_internal.h`,
`launcher.c`); no retail globals touched, MSVC reference build
unaffected.

## Test plan
- [x] Both `WC2.EXE` (MSVC reference build, byte-identical/untouched)
      and `wc2-modern.exe` build clean
- [x] `wc2-modern.exe --ega --check` runs without crashing, including
      a runtime self-test that exercises the full presentation
      contract (all 256 palette entries, both renderer paths)
- [x] Table verified byte-identical across three independent live
      captures (different files being converted in the same
      DOSBox session)