### PR TITLE
fix: restore menu cursor on secondary-view-buffer screens

### DIFF
--- a/src/dib.c
+++ b/src/dib.c
@@ -534,12 +534,16 @@ void DIBslamReal(void)
 #endif
 
 #ifdef SDL_PORT
-        /* Menus direct input to the screen; flight directs it to the
-         * offscreen view buffer while retaining the menu cursor shape.
-         * Stamp the arrow only when input belongs to the presented screen. */
+        /* Flight directs input to the offscreen space-view buffer while
+         * retaining the menu cursor shape; every other screen -- including
+         * menus that compose into the secondary view buffer, such as the
+         * campaign chalkboard, barracks, and personnel screens -- directs
+         * input to something that does end up on the presented screen.
+         * Stamp the arrow only when input isn't targeting the flight
+         * buffer specifically. */
         if (g_pInputCursorShape_005c83f9 != 0 &&
             g_pInputViewport_005c8403 != 0 &&
-            g_pInputViewport_005c8403->pixels == g_pDibPixelBuffer_005b3978 &&
+            g_pInputViewport_005c8403 != &g_stViewBuffer_005d2b00 &&
             g_stScreenViewport_005d21a0.pixels == g_pDibPixelBuffer_005b3978) {
             CaptureMouseCursorBackground();
             DrawMouseCursor();


### PR DESCRIPTION
## Summary

Fixes #46. 36ba133 ("fix: correct enhanced cockpit viewport and flight cursor") required the input viewport's pixels to exactly match the presented DIB buffer before drawing the SDL_PORT cursor. That distinguishes the screen viewport (cursor shown) from the flight offscreen buffer `g_stViewBuffer_005d2b00` (cursor correctly suppressed) -- but it also excludes the secondary view buffer `g_stSecondaryViewBuffer_005d2c90`, which is a separate allocated buffer used as the input target for the campaign chalkboard menu, the campaign-continue prompt, barracks, and personnel. None of those are flight, but all lost their cursor.

`SetInputViewport()` only ever targets three distinct buffers codebase-wide, so this checks identity against the one flight buffer specifically rather than requiring exact-match against the DIB pointer for every other case.

## Test plan

- [x] Rebuilt `WC2.EXE` (MSVC reference build, byte-identical -- change is entirely inside `#ifdef SDL_PORT`) and `wc2-modern.exe`.
- [x] Live-verified in-game: cursor now shows correctly on the title/campaign chalkboard menu, still correctly hidden during flight.