### PR TITLE
Add support for multiple joysticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ out-modern/wc2-modern-gui
 
 `make run-modern-gui` opens it with the repository's Kilrathi Saga data path.
 The launcher has a native folder picker and validates the selected DOS or
-Kilrathi Saga directory before starting the game. Its central title artwork is
+Kilrathi Saga directory before starting the game. When more than one joystick is
+detected, its device combo box chooses which one the game reads for the player.
+Its central title artwork is
 decoded from the final `WC2LOGO.VGA` menu layers with `BRIEF.PAL`, cropped to a
 small 247x101 image, and embedded in the executable. Slint 1.16.1 and [Native
 File Dialog Extended 1.3.0](https://github.com/btzy/nativefiledialog-extended)

--- a/docs/SDL2.md
+++ b/docs/SDL2.md
@@ -143,6 +143,15 @@ the game. Required data filenames
 are matched case-insensitively, and option flags supplied with `--gui` seed the
 corresponding controls.
 
+The launcher scans SDL's joystick devices itself, once its own window backend
+has started, and shows a device combo box above the control-mode row whenever it
+finds more than one. The chosen device is opened first when the game starts, so
+it becomes the joystick the game reads for the player; the remaining devices keep
+SDL's enumeration order and still fill the second slot that the twin-stick
+layouts read. A single detected device needs no choice and leaves the combo box
+hidden, and a device unplugged between the scan and the launch is ignored rather
+than failing the launch.
+
 The regular `modern` build does not contain Slint. Its no-argument startup
 reports that the launcher is unavailable and continues directly into the game.
 An explicit `--gui` instead reports the missing launcher as an error and exits.
@@ -191,6 +200,12 @@ two-button controls. SDL's mapped controller interface supplies the left stick
 and A/B buttons on recognized gamepads. Other devices use their first two axes
 and buttons. Device removal and reconnection are handled without restarting the
 port.
+
+SDL opens at most two joysticks: the first fills the slot the game reads for the
+player and the second the slot the twin-stick layouts read for their extra axes.
+With several devices attached, the graphical launcher's device combo box picks
+which one takes the first slot; without the launcher, SDL's enumeration order
+decides.
 
 The optional WCAT-style modes give each action its own button. On mapped
 gamepads, buttons 1–4 are A/B/X/Y:

--- a/include/sdl_port.h
+++ b/include/sdl_port.h
@@ -216,6 +216,7 @@ BOOL SdlReadJoystickAxisRange(unsigned int device,
                                  unsigned int *yMaximum);
 int SdlSetJoystickMode(const char *name);
 int SdlSetJoystickAxesMode(const char *name);
+void SdlSetJoystickDeviceIndex(int deviceIndex);
 void SdlEnableJoystickDebug(void);
 void SdlSetJoystickRumbleEnabled(int enabled);
 void SdlLogJoystickEvent(const SDL_Event *event);

--- a/src/sdl/joystick.c
+++ b/src/sdl/joystick.c
@@ -51,6 +51,7 @@ static int g_bSdlJoystickSpaceflightActive;
 static int g_bSdlTwoAxisModifierActive;
 static int g_nSdlCommunicationMenuSelection;
 static int g_nSdlRumblingJoystick = -1;
+static int g_nSdlPreferredJoystickDevice = -1;
 static Uint16 g_wSdlRumbleLow;
 static Uint16 g_wSdlRumbleHigh;
 static Uint32 g_dwSdlRumbleDeadline;
@@ -97,6 +98,11 @@ int SdlSetJoystickAxesMode(const char *name)
 void SdlEnableJoystickDebug(void)
 {
     g_bSdlJoystickDebug = 1;
+}
+
+void SdlSetJoystickDeviceIndex(int deviceIndex)
+{
+    g_nSdlPreferredJoystickDevice = deviceIndex >= 0 ? deviceIndex : -1;
 }
 
 void SdlSetJoystickRumbleEnabled(int enabled)
@@ -464,6 +470,7 @@ static void SdlOpenJoystick(int deviceIndex)
 static void SdlRefreshJoysticks(void)
 {
     SdlJoystickDevice *device;
+    int deviceCount;
     int deviceIndex;
     int slot;
 
@@ -476,10 +483,17 @@ static void SdlRefreshJoysticks(void)
         slot++;
     }
 
+    deviceCount = SDL_NumJoysticks();
+    /* The launcher's device opens first so it lands in slot 0, the joystick
+     * the game reads as the player's; the rest keep SDL's own order. */
+    if (g_nSdlPreferredJoystickDevice >= 0 &&
+        g_nSdlPreferredJoystickDevice < deviceCount)
+        SdlOpenJoystick(g_nSdlPreferredJoystickDevice);
     deviceIndex = 0;
-    while (deviceIndex < SDL_NumJoysticks() &&
+    while (deviceIndex < deviceCount &&
            SdlFindFreeJoystickSlot() != -1) {
-        SdlOpenJoystick(deviceIndex);
+        if (deviceIndex != g_nSdlPreferredJoystickDevice)
+            SdlOpenJoystick(deviceIndex);
         deviceIndex++;
     }
 }

--- a/src/sdl/launcher.c
+++ b/src/sdl/launcher.c
@@ -133,6 +133,30 @@ static void SdlInitializeLauncherOptions(SdlLauncherOptions *options)
         strcpy(options->gameDirectory, ".");
 }
 
+int SdlListLauncherJoystickDevices(
+    const char *names[SDL_LAUNCHER_JOYSTICK_DEVICE_CAPACITY])
+{
+    const char *name;
+    int deviceCount;
+    int deviceIndex;
+
+    /* The launcher runs before the game's own SDL_Init, so bring the joystick
+     * subsystem up here; the later SDL_Init then only adds what is missing.
+     * The main-ready flag is the same one main() sets before its SDL_Init. */
+    SDL_SetMainReady();
+    if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0)
+        return 0;
+    deviceCount = SDL_NumJoysticks();
+    deviceIndex = 0;
+    while (deviceIndex < deviceCount &&
+           deviceIndex < SDL_LAUNCHER_JOYSTICK_DEVICE_CAPACITY) {
+        name = SDL_JoystickNameForIndex(deviceIndex);
+        names[deviceIndex] = name != 0 ? name : "Unnamed joystick";
+        deviceIndex++;
+    }
+    return deviceIndex;
+}
+
 static int SdlOpenLauncherGui(SdlLauncherOptions *options)
 {
 #ifdef WC2_STATIC_GUI
@@ -160,6 +184,11 @@ static int SdlApplyLauncherOptions(const SdlLauncherOptions *options,
     *useEnhancedRenderer = options->enhancedRenderer;
     g_bSdlBalancedDifficulty = options->balancedDifficulty;
     SdlSetJoystickRumbleEnabled(options->joystickRumble);
+    /* A device that vanished while the launcher was open leaves the game on
+     * SDL's own enumeration order rather than failing the launch. */
+    if (options->joystickDevice >= 0 &&
+        options->joystickDevice < SDL_NumJoysticks())
+        SdlSetJoystickDeviceIndex(options->joystickDevice);
     SdlSetJoystickMode(
         g_apszSdlLauncherJoystickModes[options->joystickMode]);
     SdlSetJoystickAxesMode(

--- a/src/sdl/slint/launcher.cpp
+++ b/src/sdl/slint/launcher.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -192,6 +193,22 @@ int SdlRunLauncherGui(SdlLauncherOptions *options)
     window->set_cockpitless(options->cockpitless != 0);
     window->set_joystick_mode_index(options->joystickMode);
     window->set_joystick_axes_index(options->joystickAxes);
+    window->set_joystick_device_index(options->joystickDevice);
+    /* The game initializes SDL after the launcher has returned, so scan the
+     * joystick devices here. The model is set before the window is shown
+     * because its presence decides whether the window asks for the height of
+     * the device row. */
+    const char *deviceNames[SDL_LAUNCHER_JOYSTICK_DEVICE_CAPACITY] = {};
+    const int deviceCount = SdlListLauncherJoystickDevices(deviceNames);
+    auto devices =
+        std::make_shared<slint::VectorModel<slint::SharedString>>();
+
+    for (int device = 0; device < deviceCount; ++device)
+        devices->push_back(slint::SharedString(deviceNames[device]));
+    window->set_joystick_devices(devices);
+    if (options->joystickDevice >= 0 && options->joystickDevice < deviceCount) {
+        window->set_joystick_device_index(options->joystickDevice);
+    }
     refresh_window(*window);
 
     window->on_configuration_changed([&window]() {
@@ -244,5 +261,7 @@ int SdlRunLauncherGui(SdlLauncherOptions *options)
     options->cockpitless = window->get_cockpitless();
     options->joystickMode = std::max(0, window->get_joystick_mode_index());
     options->joystickAxes = std::max(0, window->get_joystick_axes_index());
+    options->joystickDevice =
+        std::max(0, window->get_joystick_device_index());
     return SDL_LAUNCHER_ACCEPTED;
 }

--- a/src/sdl/slint/launcher.slint
+++ b/src/sdl/slint/launcher.slint
@@ -12,10 +12,15 @@ import {
 export component LauncherWindow inherits Window {
     title: "Wing Commander II";
     preferred-width: 660px;
-    preferred-height: 690px;
+    /* The device combo box is one more row in the joystick group, so the
+     * window asks for the room it takes whenever that row is offered. */
+    preferred-height: 690px + (root.multiple-joysticks ? 64px : 0px);
     min-width: 580px;
     min-height: 520px;
     background: Palette.background;
+
+    private property <bool> multiple-joysticks:
+        root.joystick-devices.length > 1;
 
     in property <image> title-artwork;
     in-out property <string> game-directory;
@@ -27,6 +32,9 @@ export component LauncherWindow inherits Window {
     in-out property <bool> cockpitless;
     in-out property <int> joystick-mode-index;
     in-out property <int> joystick-axes-index;
+    in-out property <int> joystick-device-index;
+
+    in property <[string]> joystick-devices;
 
     in property <bool> path-valid: false;
     in property <bool> picker-error: false;
@@ -162,6 +170,23 @@ export component LauncherWindow inherits Window {
 
             VerticalBox {
                 spacing: 5px;
+
+                if root.multiple-joysticks : HorizontalBox {
+                    spacing: 8px;
+
+                    Text {
+                        text: "Device";
+                        vertical-alignment: center;
+                        width: 105px;
+                        color: Palette.foreground;
+                    }
+
+                    ComboBox {
+                        horizontal-stretch: 1;
+                        model: root.joystick-devices;
+                        current-index <=> root.joystick-device-index;
+                    }
+                }
 
                 HorizontalBox {
                     spacing: 8px;

--- a/src/sdl/slint/launcher_api.h
+++ b/src/sdl/slint/launcher_api.h
@@ -2,6 +2,7 @@
 #define WC2_SDL_SLINT_LAUNCHER_API_H
 
 #define SDL_LAUNCHER_DIRECTORY_CAPACITY 4096
+#define SDL_LAUNCHER_JOYSTICK_DEVICE_CAPACITY 16
 
 enum SdlLauncherResult {
     SDL_LAUNCHER_UNAVAILABLE = -2,
@@ -36,6 +37,7 @@ typedef struct SdlLauncherOptions {
     int cockpitless;
     int joystickMode;
     int joystickAxes;
+    int joystickDevice;
 } SdlLauncherOptions;
 
 #ifdef __cplusplus
@@ -43,6 +45,12 @@ extern "C" {
 #endif
 
 int SdlRunLauncherGui(SdlLauncherOptions *options);
+
+/* Fills names[] with the detected joysticks in SDL device order and returns
+ * how many entries it wrote; the returned positions are the device indices
+ * SdlSetJoystickDeviceIndex() expects. */
+int SdlListLauncherJoystickDevices(
+    const char *names[SDL_LAUNCHER_JOYSTICK_DEVICE_CAPACITY]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add a combobox to select the joystick.

This code was created with the assistance of Deepseek4 flash, but was tested locally.

Test set up:

Xbox 360 Controler,
Thrustmaster T16000m
Thrustmaster TWCS
Wacom Intuos 3 Graphics tablet that is detected as a joystick.

Fixes #48 